### PR TITLE
Enable html5mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   "rules": {
     "padded-blocks": "off",
     "brace-style": ["error", "stroustrup", { "allowSingleLine": true }],
-    "no-unused-vars": ["warn"]
+    "no-unused-vars": ["warn"],
+    "semi": [2, "never"]
   }
 }

--- a/beeline/router.js
+++ b/beeline/router.js
@@ -21,7 +21,8 @@ const introSlidesVersion = '2017-02-20'
 
 **/
 
-export default function($stateProvider, $urlRouterProvider) {
+export default function($stateProvider, $urlRouterProvider, $locationProvider) {
+
   $stateProvider
 
   // ////////////////////////////////////////////////////////////////////////////
@@ -357,6 +358,8 @@ export default function($stateProvider, $urlRouterProvider) {
       hideTabs: true,
     }
   });
+
+  $locationProvider.html5Mode(true)
 
   let viewedIntroSlidesVersion = window.localStorage['viewedBeelineSlidesVersion']
   // if none of the above states are matched, use this as the fallback

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -53,8 +53,8 @@ inquirer.prompt([
     // Replace the production hot code push files with the staging url
     shell.sed(
       "-i",
-      "app.beeline.sg",
-      "app-staging.beeline.sg",
+      "app-pages.beeline.sg",
+      "app-staging-pages.beeline.sg",
       ["www/CNAME", "www/chcp.json "]
     );
     shell.exec("gh-pages -t -d www/");

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -55,7 +55,13 @@ inquirer.prompt([
       "-i",
       "app-pages.beeline.sg",
       "app-staging-pages.beeline.sg",
-      ["www/CNAME", "www/chcp.json "]
+      ["www/CNAME"]
+    );
+    shell.sed(
+      "-i",
+      "app.beeline.sg",
+      "app-staging.beeline.sg",
+      ["www/chcp.json "]
     );
     shell.exec("gh-pages -t -d www/");
     console.log(STAGING_COMPLETE_MESSAGE);

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-app.beeline.sg
+app-pages.beeline.sg

--- a/static/grab.html
+++ b/static/grab.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <base href="/">
   <meta charset="utf-8">
   <meta name="format-detection" content="telephone=no">
   <meta name="viewport" content="initial-scale=1,

--- a/static/index.html
+++ b/static/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <base href="/">
   <meta charset="utf-8">
   <meta name="format-detection" content="telephone=no">
   <meta name="viewport" content="initial-scale=1,


### PR DESCRIPTION
This PR should only be merged in tandem with the deployment of datagovsg/beeline-frontend-proxy. 

It changes the app to use proper paths for its view URLs. The proxy is needed so that direct visits to those URLs will be served content from the index root, instead of 404ing.

Note that changes to the GitHub pages subdomain are also needed so that the proxy can take on the original ones

This PR fixes #407 