### PR TITLE
changes for lite route subscription

### DIFF
--- a/beeline/controllers/LiteDetailController.js
+++ b/beeline/controllers/LiteDetailController.js
@@ -241,6 +241,12 @@ export default [
           $scope.book.isSubscribed = false;
         }
 
+        // manage the next state to go
+        var nextState = null
+        if ($state.current && $state.current.name === 'tabs.lite-route-tracker') {
+          nextState = 'tabs.tickets'
+        }
+
         if (!$scope.book.isSubscribed) {
           await $ionicLoading.show({
             template: `
@@ -248,7 +254,7 @@ export default [
             `,
             duration: 1000,
           })
-          $state.transitionTo("tabs.routes");
+          nextState ? $state.transitionTo(nextState) : $state.transitionTo("tabs.routes");
         }
       }
       catch(err) {

--- a/beeline/controllers/LiteDetailController.js
+++ b/beeline/controllers/LiteDetailController.js
@@ -144,38 +144,13 @@ export default [
       UserService.promptLogIn()
     }
 
-    $scope.showConfirmationPopup = function() {
-      return $scope.confirmationPopup = $ionicPopup.show({
-        scope: $scope,
-        template: `
-        <div class="item item-text-wrap">
-          <div>
-              Please read {{disp.companyInfo.name}}'s <a ng-click="disp.showTerms()">Terms and Conditions of Service</a>.
-          </div>
-          <ion-checkbox ng-model="disp.termsChecked">
-            Yes, I have read and agree to the above Terms and Conditions and would like to proceed.
-          </ion-checkbox>
-        </div>
-        `,
-        cssClass: "popup-no-head",
-        buttons: [{
-          text: "Cancel",
-          type: "button-default",
-          onTap: () => {return false;},
-        },
-        {
-          text: "OK",
-          type: "button-positive",
-          onTap: (e) => {
-            if (!$scope.disp.termsChecked) {
-              e.preventDefault();
-            }
-            else {
-              $scope.followRoute();
-            }
-          },
-        }]
+    $scope.showConfirmationPopup = async function() {
+      var response = await $ionicPopup.confirm({
+        title: 'Are you sure you want to bookmark this route?',
       })
+
+      if (!response) return;
+      $scope.followRoute()
     }
 
     $scope.followRoute = async function() {
@@ -269,16 +244,6 @@ export default [
         $scope.book.waitingForSubscriptionResult = false;
       }
     };
-
-    $scope.disp.showTerms = async () => {
-      if (!$scope.book.route.transportCompanyId) return;
-
-      $scope.confirmationPopup.close();
-
-      await CompanyService.showTerms($scope.book.route.transportCompanyId)
-
-      $scope.showConfirmationPopup();
-    }
 
     $scope.hideTooltip = () => {
       if ($scope.disp.showTooltip) {

--- a/beeline/controllers/LiteDetailController.js
+++ b/beeline/controllers/LiteDetailController.js
@@ -216,12 +216,6 @@ export default [
           $scope.book.isSubscribed = false;
         }
 
-        // manage the next state to go
-        var nextState = null
-        if ($state.current && $state.current.name === 'tabs.lite-route-tracker') {
-          nextState = 'tabs.tickets'
-        }
-
         if (!$scope.book.isSubscribed) {
           await $ionicLoading.show({
             template: `
@@ -229,7 +223,11 @@ export default [
             `,
             duration: 1000,
           })
-          nextState ? $state.transitionTo(nextState) : $state.transitionTo("tabs.routes");
+          if ($state.current && $state.current.name === 'tabs.lite-route-tracker') {
+            $state.transitionTo('tabs.tickets');
+          } else {
+            $state.transitionTo("tabs.routes");
+          }
         }
       }
       catch(err) {


### PR DESCRIPTION
1. remove T&Cs in follow lite route prompt, as not needed 
2. fix next state transition after unfollow a lite route (the liteRouteDetailController is shared in 2 views, "lite-detail" in route list and "lite-tracker" in ticket page, so need to handle accordingly to the current $state)