### PR TITLE
Refactored routes list controller to make flow clearer

### DIFF
--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -59,6 +59,21 @@ export default function(
     $scope.data.placeQuery = null
     updateRoutes()
 
+    $scope.data.isFiltering = false
+    $scope.$digest()
+
+    handlePlaceQuery()
+  }
+
+  function handlePlaceQuery () {
+    if ($scope.data.placeQuery) {
+      return
+    }
+
+    if (!$scope.data.routes || !$scope.data.crowdstartRoutes) {
+      return
+    }
+
     // Check if we need to make place query
     let minNumRoutes = 3
     let performPlaceQuery = ($scope.data.routes.length 
@@ -69,8 +84,6 @@ export default function(
       // calling $scope.digest()
       getPlace()
     } else {
-      $scope.data.isFiltering = false
-      $scope.$digest()
     }
   }
 
@@ -91,6 +104,9 @@ export default function(
     if (!$scope.data.searchBoxText || !$scope.autocompleteService) {
       return
     }
+
+    $scope.data.isFiltering = true
+    $scope.$digest()
 
     // if has predicted place assign the 1st prediction to place object
     $scope.autocompleteService().getPlacePredictions({
@@ -115,8 +131,10 @@ export default function(
   }
 
   function updateNormalRoutes (allRoutes) {
-    allRoutes = allRoutes ? allRoutes : []
-    
+    if (allRoutes === null) {
+      return
+    }
+
     // Filter the routes
     if ($scope.data.placeQuery) {
       allRoutes = SearchService.filterRoutesByPlaceAndText(
@@ -132,11 +150,15 @@ export default function(
       midnightOfTrip.setHours(0, 0, 0, 0)
       return firstTripStop.time.getTime() - midnightOfTrip.getTime()
     })
+
+    handlePlaceQuery()
   }
 
   function updateRecentRoutes (recentRoutes, allRoutes) {
-    recentRoutes = recentRoutes ? recentRoutes : []
-    allRoutes = allRoutes ? allRoutes : []
+    if (recentRoutes === null || allRoutes === null) {
+      return
+    }
+
     let textFilteredAllRoutes = SearchService.filterRoutesByText(allRoutes, $scope.data.searchBoxText)
 
     // "Fill in" the recent routes with the all routes data
@@ -151,12 +173,17 @@ export default function(
     }).filter(route => route && route.id !== undefined)
 
     $scope.data.recentRoutesById = _.keyBy($scope.data.recentRoutes, 'id')
+
+    handlePlaceQuery()
   }
 
   function updateLiteRoutes (liteRoutes, subscribed) {
-    liteRoutes = liteRoutes ? liteRoutes : []
+    if (liteRoutes === null) {
+      return
+    }
+
     liteRoutes = Object.values(liteRoutes)
-    
+
     // Filter the routes
     if ($scope.data.placeQuery) {
       liteRoutes = SearchService.filterRoutesByPlaceAndText(
@@ -175,10 +202,15 @@ export default function(
     $scope.data.liteRoutes = _.sortBy(liteRoutes, route => {
       return parseInt(route.label.slice(1));
     });
+
+    handlePlaceQuery()
   }
 
   function updateActivatedKickstarterRoutes (kickstartedRoutes) {
-    kickstartedRoutes = kickstartedRoutes ? kickstartedRoutes : []
+    if (kickstartedRoutes === null) {
+      return
+    }
+
     if ($scope.data.placeQuery) {
       $scope.data.activatedCrowdstartRoutes = SearchService.filterRoutesByPlaceAndText(
         kickstartedRoutes, $scope.data.placeQuery, $scope.data.searchBoxText)
@@ -186,11 +218,14 @@ export default function(
       $scope.data.activatedCrowdstartRoutes = SearchService.filterRoutesByText(
         kickstartedRoutes, $scope.data.searchBoxText)
     }
+
+    handlePlaceQuery()
   }
 
   function updateBackedKickstarterRoutes (routes, bids) {
-    routes = routes ? routes : []
-    bids = bids ? bids : []
+    if (routes === null || bids === null) {
+      return
+    }
 
     // Filter to the routes the user bidded on
     let biddedRouteIds = bids.map(bid => bid.routeId);
@@ -216,11 +251,15 @@ export default function(
     $scope.data.biddedCrowdstartRoutes = _.sortBy(routes, route => {
       return parseInt(route.label.slice(1));
     });
+
+    handlePlaceQuery()
   }
 
   function updateUnactivatedKickstarterRoutes (routes, bids) {
-    routes = routes ? routes : []
-    bids = bids ? bids : []
+    if (routes === null || bids === null) {
+      return
+    }
+
     // Filter out the routes the user bidded on
     // These are already shown elsewhere
     let biddedRouteIds = bids.map(bid => bid.routeId);
@@ -244,6 +283,7 @@ export default function(
       return parseInt(route.label.slice(1));
     });
 
+    handlePlaceQuery()
   }
   // ---------------------------------------------------------------------------
   // UI Hooks

--- a/static/templates/routes-list.html
+++ b/static/templates/routes-list.html
@@ -7,14 +7,14 @@
         <input
           id="search"
           type="text"
-          ng-model="data.queryText"
+          ng-model="data.searchBoxText"
           placeholder="Search Routes"
         />
         <ion-spinner ng-show="data.isFiltering"></ion-spinner>
         <i
           class="icon ion-android-close"
-          on-tap="data.queryText = ''"
-          ng-show="data.queryText.length > 0"
+          on-tap="data.searchBoxText = ''"
+          ng-show="data.searchBoxText.length > 0"
         ></i>
       </label>
     </div>
@@ -78,13 +78,13 @@
 
         <!-- Route you may like -->
         <!-- hide it if search bar is not empty -->
-        <div class="item item-divider" ng-if="data.routesYouMayLike.length > 0 && !data.queryText">
+        <div class="item item-divider" ng-if="data.routesYouMayLike.length > 0 && !data.searchBoxText">
           Routes You May Like
         </div>
         <!-- hide route item if search bar is not empty -->
         <ion-item
           ng-repeat="route in data.routesYouMayLike"
-          ng-if="!data.queryText"
+          ng-if="!data.searchBoxText"
           ui-sref="tabs.route-detail({
             routeId: route.id
           })"
@@ -161,7 +161,7 @@
               data.placeQuery"
         class="not-found-message text-center"
       >
-        Sorry, we could not find any routes matching "{{data.queryText}}".
+        Sorry, we could not find any routes matching "{{data.searchBoxText}}".
       </p>
     </ion-content>
 

--- a/www/templates/routes-list.html
+++ b/www/templates/routes-list.html
@@ -7,14 +7,14 @@
         <input
           id="search"
           type="text"
-          ng-model="data.queryText"
+          ng-model="data.searchBoxText"
           placeholder="Search Routes"
         />
         <ion-spinner ng-show="data.isFiltering"></ion-spinner>
         <i
           class="icon ion-android-close"
-          on-tap="data.queryText = ''"
-          ng-show="data.queryText.length > 0"
+          on-tap="data.searchBoxText = ''"
+          ng-show="data.searchBoxText.length > 0"
         ></i>
       </label>
     </div>
@@ -78,13 +78,13 @@
 
         <!-- Route you may like -->
         <!-- hide it if search bar is not empty -->
-        <div class="item item-divider" ng-if="data.routesYouMayLike.length > 0 && !data.queryText">
+        <div class="item item-divider" ng-if="data.routesYouMayLike.length > 0 && !data.searchBoxText">
           Routes You May Like
         </div>
         <!-- hide route item if search bar is not empty -->
         <ion-item
           ng-repeat="route in data.routesYouMayLike"
-          ng-if="!data.queryText"
+          ng-if="!data.searchBoxText"
           ui-sref="tabs.route-detail({
             routeId: route.id
           })"
@@ -161,7 +161,7 @@
               data.placeQuery"
         class="not-found-message text-center"
       >
-        Sorry, we could not find any routes matching "{{data.queryText}}".
+        Sorry, we could not find any routes matching "{{data.searchBoxText}}".
       </p>
     </ion-content>
 


### PR DESCRIPTION
Made the flow for search more obvious by not watching on placeQuery any more.

So the model hooks are now simple, and just do a filter if the model changes.

For search, look at `newSearch`. It currently does a text filter on all routes, then based on that figures out if we need to do a place query and performs it.

A few iffy things that I may be doing:
* Setting `$scope.data.isFiltering` and calling `$scope.digest()` in `getPlaces()`. It's no worse than what we were doing before (doing that in `autocomplete`), but it means that there's the clunky if/else in lines 66-74.
* When the model changes, I don't check again if we need to do a place query (I'm not sure how major this is)

The git diff is kinda bad so it might be easier to just look at the file directly.