### PR TITLE
show ticket pings which were within past 2 hours

### DIFF
--- a/beeline/controllers/TicketMapViewController.js
+++ b/beeline/controllers/TicketMapViewController.js
@@ -126,11 +126,11 @@ export default [
           }
           MapService.emit('ticketInfo', ticketInfo)
           const now = Date.now()
-
+          // mark ticket ping as recent if it was not more than 2 hours from now
           $scope.mapObject.allRecentPings[index] = {
             ...info,
             isRecent: info.pings[0] &&
-              (now - info.pings[0].time.getTime()) < 5 * 60000,
+              (now - info.pings[0].time.getTime()) < 2 * 60 * 60000,
           }
 
           $scope.mapObject.statusMessages[index] = _.get(info, 'statuses[0].message', null)


### PR DESCRIPTION
This was the setting prior we changed to use 1 map instance, and also the reason why those users who change clock time ahead still can view ticket pings 