### PR TITLE
dynamic html5Mode

### DIFF
--- a/beeline/main.js
+++ b/beeline/main.js
@@ -150,8 +150,18 @@ app
 .directive('countdown', require('./directives/countdown.js').default)
 .config(configureRoutes)
 .config(['$locationProvider', function ($locationProvider) {
+  // XXX: Here be dragons
   // Turn on html5Mode only if we are sure we are not a cordova app
+  // Further, Ionic breaks if the root document has a base tag, and we
+  // cannot use html5Mode({enabled:true, requireBase: false}) as that
+  // breaks all the routes in the app
+  // Instead, _dynamically inject_ a base tag into the root document when
+  // we realise that we are not cordova, to keep both sides happy
   if (!window.cordova) {
+    const base = window.document.createElement('base')
+    base.setAttribute('href', '/')
+    const [head] = window.document.getElementsByTagName('head')
+    head.appendChild(base)
     $locationProvider.html5Mode({enabled: true})
   }
 }])

--- a/beeline/main.js
+++ b/beeline/main.js
@@ -149,6 +149,12 @@ app
 .directive('liteRoute', require('./directives/routeItem/liteRoute.js').default)
 .directive('countdown', require('./directives/countdown.js').default)
 .config(configureRoutes)
+.config(['$locationProvider', function ($locationProvider) {
+  // Turn on html5Mode only if we are sure we are not a cordova app
+  if (!window.cordova) {
+    $locationProvider.html5Mode({enabled: true})
+  }
+}])
 .config(['$ionicConfigProvider', function($ionicConfigProvider) {
   $ionicConfigProvider.tabs.position('bottom');
   $ionicConfigProvider.tabs.style('standard');

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -53,9 +53,15 @@ inquirer.prompt([
     // Replace the production hot code push files with the staging url
     shell.sed(
       "-i",
+      "app-pages.beeline.sg",
+      "app-staging-pages.beeline.sg",
+      ["www/CNAME"]
+    );
+    shell.sed(
+      "-i",
       "app.beeline.sg",
       "app-staging.beeline.sg",
-      ["www/CNAME", "www/chcp.json "]
+      ["www/chcp.json "]
     );
     shell.exec("gh-pages -t -d www/");
     console.log(STAGING_COMPLETE_MESSAGE);

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-app.beeline.sg
+app-pages.beeline.sg


### PR DESCRIPTION
* Change scripts/deploy.js to point to -pages domains so that we can
repurpose the original ones for the proxies

* Ensure that we turn this on at runtime _only_ if this is an angular app,
ie, don’t do this for Cordova.

* Create a hack to appease both angular html5mode and ionic, per comments
   * If we are cordova, ensure `html5Mode` false, no `<base>` tag
   * If we are angular, ensure `html5Mode` true, `<base>` tag present

`html5Mode` with `requireBase: false` is not an option as it breaks all
angular routes. We are left with no choice but to dynamically inject a tag
depending on whether `window.cordova` is present.

Tested both by loading into a phone and running on local dev machine in conjunction with [beeline-frontend-proxy](https://github.com/datagovsg/beeline-frontend-proxy)

**DO NOT MERGE** - a rebuild is scheduled for the App Store and Android Play. Merge these changes in only _after_ that has happened.