### PR TITLE
Fix build for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ Run `npm run install-android`
 ## iOS development
 NOTE: Cordova 7.x is not supported until nordnet/cordova-hot-code-push-local-dev-addon#20 merged  
 Install [Xcode](https://developer.apple.com/xcode/) for iOS development  
+
 Run `npm run install-ios`
+
+When prompted whether to overwrite `config.xml` and `resources/`, select `No`
+
+Open `platforms/ios/Beeline.xcodeproj` in Xcode
+
+Select target platform to run (e.g. iPhone 6) and run it
 
 # Building 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Install [Android Studio](https://developer.android.com/studio/index.html)
 Run `npm run install-android`
 
 ## iOS development
-NOTE: Cordova 7.x is not supported until nordnet/cordova-hot-code-push-local-dev-addon#20 merged  
+NOTE: Cordova 7.x is not supported until nordnet/cordova-hot-code-push-local-dev-addon#20 merged. This is why in `package.json` we set the cordova version to `^6.5.0`.
+
 Install [Xcode](https://developer.apple.com/xcode/) for iOS development  
 
 Run `npm run install-ios`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clipboard": "^1.5.15",
     "commonmark": "^0.28.1",
     "compare-versions": "^3.0.0",
+    "cordova": "^6.5.0",
     "cordova-android": "6.3.0",
     "cordova-ios": "^4.4.0",
     "cordova-plugin-app-version": "~0.1.9",

--- a/package.json
+++ b/package.json
@@ -145,8 +145,7 @@
         "DEEPLINK_5_SCHEME": " ",
         "DEEPLINK_5_HOST": " "
       },
-      "cordova-hot-code-push-plugin": {},
-      "cordova-hot-code-push-local-dev-addon": {}
+      "cordova-hot-code-push-plugin": {}
     },
     "platforms": [
       "android"


### PR DESCRIPTION
1. Removed `cordova-hot-code-push-local-dev-addon`
1. Add `cordova` version 6
1. Extend README with some simple instructions on how to build for iOS