### PR TITLE
Location tracking - Rework polling

### DIFF
--- a/beeline/controllers/LiteMapViewController.js
+++ b/beeline/controllers/LiteMapViewController.js
@@ -50,62 +50,93 @@ export default [
       $scope.mapObject.pingTrips = trips
     })
 
-    // fetch driver pings every 4s
-    $scope.timeout = new SafeInterval(pingLoop, 4000, 1000)
-
-    MapService.once("killPingLoop", () => {
-      $scope.timeout.stop()
-    })
-
-    MapService.once("startPingLoop", () => {
-      $scope.timeout.start()
-    })
-
-    // load icons and path earlier by restart timeout on watching trips
-    $scope.$watchCollection("mapObject.pingTrips", pt => {
-      $scope.timeout.stop()
-
-      if (pt) {
-        $scope.timeout.start()
-      }
-    })
-
-    async function pingLoop() {
-      if (!$scope.mapObject.pingTrips) return
-      $scope.mapObject.statusMessages = $scope.mapObject.statusMessages || []
-      $scope.mapObject.allRecentPings = $scope.mapObject.allRecentPings || []
-
-      $scope.mapObject.statusMessages.length = $scope.mapObject.allRecentPings.length =
-        $scope.mapObject.pingTrips.length
-      await Promise.all(
-        $scope.mapObject.pingTrips.map((trip, index) => {
-          return TripService.driverPings(trip.id).then(async info => {
-            const now = ServerTime.getTime()
-            $scope.mapObject.allRecentPings[index] = {
-              ...info,
-              isRecent:
-                info.pings[0] && now - info.pings[0].time.getTime() < 5 * 60000,
-            }
-
-            $scope.mapObject.statusMessages[index] = _.get(
-              info,
-              "statuses[0].message",
-              null
-            )
-          })
-        })
-      )
+    const updateTripInfo = () => {
       // to mark no tracking data if no ping or pings are too old
       // isRecent could be undefined(no pings) or false (pings are out-dated)
       $scope.hasTrackingData = _.any(
         $scope.mapObject.allRecentPings,
         "isRecent"
       )
-      let tripInfo = {
+      MapService.emit("tripInfo", {
         hasTrackingData: $scope.hasTrackingData,
         statusMessages: $scope.mapObject.statusMessages.join(" "),
+      })
+    }
+
+    // fetch driver pings every 4s
+    $scope.timeout = new SafeInterval(pingLoop, 4000, 1000)
+    $scope.statusTimeout = new SafeInterval(statusLoop, 60000, 1000)
+
+    MapService.once("killPingLoop", () => {
+      $scope.timeout.stop()
+      $scope.statusTimeout.stop()
+      MapService.removeListener("ping", updateTripInfo)
+    })
+
+    MapService.once("startPingLoop", () => {
+      $scope.timeout.start()
+      $scope.statusTimeout.start()
+      MapService.on("ping", updateTripInfo)
+    })
+
+    // load icons and path earlier by restart timeout on watching trips
+    $scope.$watchCollection("mapObject.pingTrips", pt => {
+      if (pt) {
+        $scope.timeout.stop()
+        $scope.timeout.start()
       }
-      MapService.emit("tripInfo", tripInfo)
+    })
+
+    /**
+     * Request driver pings for the given trip
+     */
+    async function pingLoop() {
+      if (!$scope.mapObject.pingTrips) return
+
+      $scope.mapObject.allRecentPings = $scope.mapObject.allRecentPings || []
+      $scope.mapObject.allRecentPings.length = $scope.mapObject.pingTrips.length
+
+      await Promise.all(
+        $scope.mapObject.pingTrips.map((trip, index) => {
+          return TripService.driverPings(trip.id).then(pings => {
+            const [ping] = pings || []
+            if (ping) {
+              const now = ServerTime.getTime()
+              $scope.mapObject.allRecentPings[index] = {
+                pings,
+                isRecent: now - ping.time.getTime() < 5 * 60000,
+              }
+              MapService.emit("ping", ping)
+            }
+          })
+        })
+      )
+    }
+
+    /**
+     * Request status messages for the given trip
+     */
+    async function statusLoop() {
+      if (!$scope.mapObject.pingTrips) return
+
+      $scope.mapObject.statusMessages = $scope.mapObject.statusMessages || []
+      $scope.mapObject.statusMessages.length = $scope.mapObject.pingTrips.length
+
+      $scope.mapObject.pingTrips.map((trip, index) => {
+        return TripService.statuses(trip.id).then(statuses => {
+          const status = _.get(statuses, "[0]", null)
+
+          $scope.mapObject.statusMessages[index] = _.get(
+            status,
+            "message",
+            null
+          )
+
+          if (status) {
+            MapService.emit("status", status)
+          }
+        })
+      })
     }
   },
 ]

--- a/beeline/controllers/LiteMapViewController.js
+++ b/beeline/controllers/LiteMapViewController.js
@@ -50,7 +50,7 @@ export default [
       $scope.mapObject.pingTrips = trips
     })
 
-    // fetch driver pings every 4s
+    // fetch driver pings every 4s and statuses every 60s
     $scope.timeout = new SafeInterval(pingLoop, 4000, 1000)
     $scope.statusTimeout = new SafeInterval(statusLoop, 60000, 1000)
 

--- a/beeline/controllers/TicketMapViewController.js
+++ b/beeline/controllers/TicketMapViewController.js
@@ -124,21 +124,23 @@ export default [
       $scope.mapObject.statusMessages = $scope.mapObject.statusMessages || []
       $scope.mapObject.statusMessages.length = $scope.mapObject.pingTrips.length
 
-      $scope.mapObject.pingTrips.map((trip, index) => {
-        return TripService.statuses(trip.id).then(statuses => {
-          const status = _.get(statuses, "[0]", null)
+      await Promise.all(
+        $scope.mapObject.pingTrips.map((trip, index) => {
+          return TripService.statuses(trip.id).then(statuses => {
+            const status = _.get(statuses, "[0]", null)
 
-          $scope.mapObject.statusMessages[index] = _.get(
-            status,
-            "message",
-            null
-          )
+            $scope.mapObject.statusMessages[index] = _.get(
+              status,
+              "message",
+              null
+            )
 
-          if (status) {
-            MapService.emit("status", status)
-          }
+            if (status) {
+              MapService.emit("status", status)
+            }
+          })
         })
-      })
+      )
     }
   },
 ]

--- a/beeline/services/TripService.js
+++ b/beeline/services/TripService.js
@@ -18,14 +18,32 @@ export default [
         assert(typeof id === "number")
         return UserService.beeline({
           method: "GET",
-          url: "/trips/" + id + "/latestInfo",
+          url: `/trips/${id}/pingsByTripId?limit=20`,
           timeout: 10000,
         }).then(function(response) {
-          for (let ping of response.data.pings) {
+          for (let ping of response.data) {
             ping.time = new Date(ping.time)
           }
           return response.data
         })
+      },
+
+      latestInfo: function(id) {
+        assert(typeof id === "number")
+        return UserService.beeline({
+          method: "GET",
+          url: `/trips/${id}/latest_info`,
+          timeout: 10000,
+        }).then(response => response.data)
+      },
+
+      statuses: function(id) {
+        assert(typeof id === "number")
+        return UserService.beeline({
+          method: "GET",
+          url: `/trips/${id}/statuses?limit=5`,
+          timeout: 10000,
+        }).then(response => response.data)
       },
     }
   },


### PR DESCRIPTION
As far as location tracking is concerned, treat beeline-server as a reference data service

* Ticket*Controller - Poll for `/statuses` once every minute, and use that to
update `$scope.disp.status`, as opposed to using `/latest_info`
* LiteMapViewController - bring in line with TicketMapViewController
* TicketDetailController - look up `/latest_info` only if we realise that the pings have
changed `vehicleId` or `driverId`
* TripService - Poll for pings using `/pingsByTripId`

TODO: Implement missing functionality in beeline-tracking so that we can point to it
for the last n pings for a trip