### PR TITLE
Point to beeline-tracking for pings

### DIFF
--- a/beeline/services/TripService.js
+++ b/beeline/services/TripService.js
@@ -16,9 +16,9 @@ export default [
 
       driverPings: function(id) {
         assert(typeof id === "number")
-        return UserService.beeline({
+        return UserService.tracking({
           method: "GET",
-          url: `/trips/${id}/pingsByTripId?limit=20`,
+          url: `/trips/${id}/pings?limit=20`,
           timeout: 10000,
         }).then(function(response) {
           for (let ping of response.data) {

--- a/beeline/services/UserService.js
+++ b/beeline/services/UserService.js
@@ -68,6 +68,11 @@ export default [
       return $http(options)
     }
 
+    const tracking = function(options) {
+      options.url = process.env.TRACKING_URL + options.url
+      return $http(options)
+    }
+
     // Requests a verification code to be sent to a mobile number
     // Verification code is used to log in
     let sendTelephoneVerificationCode = function(number) {
@@ -138,7 +143,7 @@ export default [
     }
 
     // Updates user fields
-    function updateUserInfo(update) {
+    const updateUserInfo = function(update) {
       return beelineRequest({
         method: "PUT",
         url: "/user",
@@ -350,7 +355,7 @@ export default [
     // Use the referral code and apply rewards to newUser
     // Input:
     // - refCode - String: referral code
-    async function applyRefCode(refCode) {
+    const applyRefCode = async function(refCode) {
       return beelineRequest({
         method: "POST",
         url: "/user/applyRefCode",
@@ -360,7 +365,7 @@ export default [
       })
     }
 
-    async function checkNewUser(user) {
+    const checkNewUser = async function(user) {
       if (user.name || user.email) {
         // Not a new user
         return
@@ -532,9 +537,9 @@ export default [
       })
     }
 
-    let sendEmailVerification = function () {
+    let sendEmailVerification = function() {
       return beelineRequest({
-        method: 'POST',
+        method: "POST",
         url: `/users/sendEmailVerification`,
       })
     }
@@ -552,6 +557,7 @@ export default [
         return user
       },
       beeline: beelineRequest,
+      tracking,
       promptLogIn,
       loginIfNeeded,
       promptUpdatePhone,

--- a/beeline/services/UserService.js
+++ b/beeline/services/UserService.js
@@ -68,7 +68,15 @@ export default [
       return $http(options)
     }
 
-    const tracking = function(options) {
+    /**
+     * Send a standard http request to the endpoint defined in
+     * `process.env.TRACKING_URL`. Usually used to retrieve recent pings to
+     * determine trip vehicle location and bearing
+     * @param {object} options - the standard options object, with one
+     * exception - the url specified will be relative to `process.env.TRACKING_URL`
+     * @return {object} the $http response
+     */
+    function tracking(options) {
       options.url = process.env.TRACKING_URL + options.url
       return $http(options)
     }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,12 +1,12 @@
 /* eslint no-console: 0 */
-const shell = require("shelljs");
-const assert = require("assert");
+const shell = require("shelljs")
+const assert = require("assert")
 
-const BUILD_STARTED_MESSAGE = "Beeline frontend build process started";
-const DEFAULT_BACKEND_URL = "https://api.beeline.sg";
+const BUILD_STARTED_MESSAGE = "Beeline frontend build process started"
+const DEFAULT_BACKEND_URL = "https://api.beeline.sg"
 const NO_WATCH_AND_PRODUCTION_MESSAGE = `
 Watch and production flags cannot be used together
-`;
+`
 const BACKEND_URL_NOT_SET_MESSAGE = `
 BACKEND_URL environment variable not set. Defaulting to ${DEFAULT_BACKEND_URL}
 `
@@ -17,7 +17,7 @@ const TRACKING_URL_NOT_SET_MESSAGE = `
 TRACKING_URL environment variable not set. Defaulting to ${DEFAULT_TRACKING_URL}
 `
 
-const BUILD_COMPLETED_MESSAGE = "Beeline frontend build process complete";
+const BUILD_COMPLETED_MESSAGE = "Beeline frontend build process complete"
 const PRODUCTION_BUILD_MESSAGE = `
 Starting production build. Remove the --production flag for development builds
 `
@@ -26,39 +26,39 @@ Starting development build. Use the --production flag for production builds
 `
 
 // Check Flags
-const production = process.argv.indexOf("--production") >= 0;
-const watch = process.argv.indexOf("--watch") >= 0;
-assert(!(watch && production), NO_WATCH_AND_PRODUCTION_MESSAGE);
+const production = process.argv.indexOf("--production") >= 0
+const watch = process.argv.indexOf("--watch") >= 0
+assert(!(watch && production), NO_WATCH_AND_PRODUCTION_MESSAGE)
 
 // Build
-console.log(BUILD_STARTED_MESSAGE);
+console.log(BUILD_STARTED_MESSAGE)
 // Clear away the old output and start fresh from template
-shell.rm("-rf", "www/");
-shell.cp("-r", "static/", "www/");
+shell.rm("-rf", "www/")
+shell.cp("-r", "static/", "www/")
 // Do a copy watch
 if (watch) shell.exec(
   "cpx 'static/**/*' www/ --watch --no-initial",
   { async: true }
-);
+)
 // Build switching based on production or non production
 if (production) {
-  console.log(PRODUCTION_BUILD_MESSAGE);
-  shell.exec("webpack -p");
-  shell.exec("cordova-hcp build www/");
-  shell.exec("touch www/.nojekyll");
+  console.log(PRODUCTION_BUILD_MESSAGE)
+  shell.exec("webpack -p")
+  shell.exec("cordova-hcp build www/")
+  shell.exec("touch www/.nojekyll")
 } else {
-  console.log(NON_PRODUCTION_BUILD_MESSAGE);
+  console.log(NON_PRODUCTION_BUILD_MESSAGE)
   // Configure default environment variables for non production builds
   if (typeof process.env.BACKEND_URL === 'undefined') {
-    console.log(BACKEND_URL_NOT_SET_MESSAGE);
-    process.env.BACKEND_URL = DEFAULT_BACKEND_URL;
+    console.log(BACKEND_URL_NOT_SET_MESSAGE)
+    process.env.BACKEND_URL = DEFAULT_BACKEND_URL
   }
   // Configure default environment variables for non production builds
   if (typeof process.env.TRACKING_URL === 'undefined') {
     console.log(TRACKING_URL_NOT_SET_MESSAGE)
     process.env.TRACKING_URL = DEFAULT_TRACKING_URL
   }
-  if (watch) { shell.exec("webpack -w", { async: true }); }
-  else { shell.exec("webpack"); }
+  if (watch) { shell.exec("webpack -w", { async: true }) }
+  else { shell.exec("webpack") }
 }
-console.log(BUILD_COMPLETED_MESSAGE);
+console.log(BUILD_COMPLETED_MESSAGE)

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 const shell = require("shelljs");
 const assert = require("assert");
 
@@ -9,6 +10,13 @@ Watch and production flags cannot be used together
 const BACKEND_URL_NOT_SET_MESSAGE = `
 BACKEND_URL environment variable not set. Defaulting to ${DEFAULT_BACKEND_URL}
 `
+
+
+const DEFAULT_TRACKING_URL = "https://tracking.beeline.sg"
+const TRACKING_URL_NOT_SET_MESSAGE = `
+TRACKING_URL environment variable not set. Defaulting to ${DEFAULT_TRACKING_URL}
+`
+
 const BUILD_COMPLETED_MESSAGE = "Beeline frontend build process complete";
 const PRODUCTION_BUILD_MESSAGE = `
 Starting production build. Remove the --production flag for development builds
@@ -44,6 +52,11 @@ if (production) {
   if (typeof process.env.BACKEND_URL === 'undefined') {
     console.log(BACKEND_URL_NOT_SET_MESSAGE);
     process.env.BACKEND_URL = DEFAULT_BACKEND_URL;
+  }
+  // Configure default environment variables for non production builds
+  if (typeof process.env.TRACKING_URL === 'undefined') {
+    console.log(TRACKING_URL_NOT_SET_MESSAGE)
+    process.env.TRACKING_URL = DEFAULT_TRACKING_URL
   }
   if (watch) { shell.exec("webpack -w", { async: true }); }
   else { shell.exec("webpack"); }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
+/* eslint no-console: 0 */
 const path = require("path")
-const fs = require("fs")
 const assert = require("assert")
 const ExtractTextPlugin = require("extract-text-webpack-plugin")
 const InlineEnviromentVariablesPlugin = require("inline-environment-variables-webpack-plugin")
@@ -16,7 +16,17 @@ if (typeof process.env.BACKEND_URL === "undefined") {
   process.env.BACKEND_URL = DEFAULT_BACKEND_URL
 }
 
-const INLINED_ENVIRONMENT_VARIABLES = ["BACKEND_URL"]
+const DEFAULT_TRACKING_URL = "https://tracking.beeline.sg"
+const TRACKING_URL_NOT_SET_MESSAGE = `
+TRACKING_URL environment variable not set. Defaulting to ${DEFAULT_TRACKING_URL}
+`
+if (typeof process.env.TRACKING_URL === "undefined") {
+  console.log(TRACKING_URL_NOT_SET_MESSAGE)
+  process.env.TRACKING_URL = DEFAULT_TRACKING_URL
+}
+
+
+const INLINED_ENVIRONMENT_VARIABLES = ["BACKEND_URL", "TRACKING_URL"]
 
 INLINED_ENVIRONMENT_VARIABLES.forEach(function(key) {
   assert(process.env[key], "process.env." + key + " must be set")


### PR DESCRIPTION
Define `UserService.tracking` which depends on a new env var, `TRACKING_URL`.
This will point to tracking.beeline.sg in the build files, so that we can stop hitting
beeline-server for our ping locations