### PR TITLE
Data munging cleanup

### DIFF
--- a/beeline/common/BookingService.js
+++ b/beeline/common/BookingService.js
@@ -33,42 +33,17 @@ angular.module("common").service("BookingService", [
           method: "POST",
           url: "/transactions/tickets/quote",
           data: {
-            // creditTag: booking.applyRoutePass ? booking.creditTag : null,
             trips: trips,
             dryRun: true,
-            promoCode: booking.promoCode
-              ? {
-                  code: booking.promoCode,
-                }
-              : {
-                  code: "", // Allow default promo codes to be used
-                },
-            applyCredits: booking.applyCredits,
-            applyReferralCredits: booking.applyReferralCredits,
+            promoCode: { code: booking.promoCode || "" },
             applyRoutePass: !!booking.applyRoutePass,
+            groupItemsByType: true,
           },
         })
           .then(resp => {
-            // Find the 'payment' entry in the list of transaction itemss
-            let txItems = _.groupBy(resp.data.transactionItems, "itemType")
-            let totalBeforeDiscount = _.reduce(
-              txItems.ticketSale,
-              (sum, n) => {
-                return sum + parseFloat(n.credit)
-              },
-              0
-            )
-
-            // FIXME: include discounts, vouchers
             return {
-              totalDue: txItems.payment[0].debit,
-              tripCount: trips.length,
-              pricesPerTrip: this.summarizePrices(booking),
-              routePass: txItems["routePass"],
-              referralCredits: txItems["referralCredits"],
-              credits: txItems["userCredit"],
-              discounts: txItems.discount,
-              totalBeforeDiscount,
+              ...resp.data.transactionItems,
+              totals: resp.data.totals,
             }
           })
           .then(null, err => {

--- a/beeline/controllers/BookingHistoryController.js
+++ b/beeline/controllers/BookingHistoryController.js
@@ -37,6 +37,7 @@ export default [
           qs.stringify({
             page: $scope.page,
             perPage: $scope.perPage,
+            groupItemsByType: true,
           }),
       })
         .then(response => {
@@ -49,40 +50,16 @@ export default [
             $scope.hasMoreData = false
           }
 
-          for (let t of newTransactions) {
-            t.itemsByType = _.groupBy(t.transactionItems, ti => ti.itemType)
-          }
-
           // add route information to ticket sale items and route credit items
           routesPromise.then(() => {
             for (let t of newTransactions) {
-              for (let ticketSaleItem of t.itemsByType.ticketSale || []) {
-                ticketSaleItem.route =
-                  $scope.routesById[
-                    ticketSaleItem.ticketSale.boardStop.trip.routeId
-                  ]
-              }
-              for (let ticketRefundItem of t.itemsByType.ticketRefund || []) {
-                ticketRefundItem.route =
-                  $scope.routesById[
-                    ticketRefundItem.ticketRefund.boardStop.trip.routeId
-                  ]
-              }
-              for (let ticketExpenseItem of t.itemsByType.ticketExpense || []) {
-                ticketExpenseItem.route =
-                  $scope.routesById[
-                    ticketExpenseItem.ticketExpense.boardStop.trip.routeId
-                  ]
-              }
-              for (let routeCreditItem of t.itemsByType.routeCredits || []) {
-                const tag = routeCreditItem.routeCredits.tag
-                routeCreditItem.route =
-                  $scope.routesById[tag.substring(tag.indexOf("-") + 1)]
-              }
-              for (let routePassItem of t.itemsByType.routePass || []) {
-                const tag = routePassItem.routePass.tag
-                routePassItem.route =
-                  $scope.routesById[tag.substring(tag.indexOf("-") + 1)]
+              for (const item of t.itemsByType.deal || []) {
+                const tag = (item.routeCredits || item.routePass || {}).tag
+                const ticket = item.ticketSale || item.ticketRefund || item.ticketExpense
+                const routeId = tag
+                  ? tag.substring(tag.indexOf("-") + 1)
+                  : ticket.boardStop.trip.routeId
+                item.route = $scope.routesById[routeId]
               }
             }
           })

--- a/beeline/controllers/KickstarterSummaryController.js
+++ b/beeline/controllers/KickstarterSummaryController.js
@@ -51,7 +51,7 @@ export default [
     $scope.data = {
       hasCreditInfo: false,
       brand: null,
-      last4Digtis: null,
+      last4Digits: null,
     }
     $scope.disp = {
       bidded,
@@ -103,7 +103,7 @@ export default [
 
               if ($scope.data.hasCreditInfo) {
                 $scope.data.brand = paymentInfo.sources.data[0].brand
-                $scope.data.last4Digtis = paymentInfo.sources.data[0].last4
+                $scope.data.last4Digits = paymentInfo.sources.data[0].last4
               }
             }
           )

--- a/beeline/directives/priceCalculator/priceCalculator.html
+++ b/beeline/directives/priceCalculator/priceCalculator.html
@@ -8,19 +8,19 @@
     <tbody>
       <tr>
         <td>{{booking.selectedDates.length}} Ticket{{ booking.selectedDates.length > 1 ? 's' : '' }}{{pricePerTrip ? ' x $' + pricePerTrip : ''}}</td>
-        <td class="right">{{(priceInfo.totalBeforeDiscount || 0) | currency}}</td>
+        <td class="right">{{(priceInfo.totals.ticketSale.credit || 0) | currency}}</td>
       </tr>
       <tr ng-if="priceInfo.routePass && priceInfo.routePass.length > 0">
         <td>Using {{ ridesUsed }} route pass{{ ridesUsed > 1 ? 'es' : '' }}</td>
-        <td class="right">{{totalRoutePassesUsed | currency}}</td>
+        <td class="right">{{-priceInfo.totals.routePass.debit | currency}}</td>
       </tr>
-      <tr ng-if="priceInfo.discounts && priceInfo.discounts.length > 0" ng-repeat="discount in priceInfo.discounts">
+      <tr ng-if="priceInfo.discount && priceInfo.discount.length > 0" ng-repeat="d in priceInfo.discount">
         <td>
-          {{discount.discount.description}}<span ng-if="booking.promoCode">: {{discount.discount.code}}
+          {{d.discount.description}}<span ng-if="booking.promoCode">: {{d.discount.code}}
           <i class="icon ion-close-circled" ng-click="removePromoCode()"></i></span>
         </td>
         <td class="right">
-          {{(-discount.debit || 0) | currency}}
+          {{(-d.debit || 0) | currency}}
         </td>
       </tr>
       <tr ng-if="priceInfo.referralCredits && priceInfo.referralCredits.length > 0" ng-repeat="referralCredit in priceInfo.referralCredits">
@@ -33,7 +33,7 @@
       </tr>
       <tr>
         <td class="total-sum left" ><b>Total</b></td>
-        <td class="total-sum right"><b>{{ (priceInfo.totalDue || 0) | currency}}</b></td>
+        <td class="total-sum right"><b>{{ (priceInfo.totals.payment.debit || 0) | currency}}</b></td>
       </tr>
       <!-- FIXME: include vouchers, discounts here -->
     </tbody>

--- a/beeline/services/data/RoutesService.js
+++ b/beeline/services/data/RoutesService.js
@@ -490,36 +490,11 @@ angular.module("beeline").factory("RoutesService", [
           url: `/routes/${routeId}/price_schedule`,
         })
           .then(function(response) {
-            let priceSchedules = []
-            _.forEach(response.data, (value, key) => {
-              let quantity = parseInt(key)
-              let singleSchedule = null
-              if (quantity === 1) {
-                singleSchedule = {
-                  quantity: 1,
-                  price: parseFloat(value.price),
-                  totalPrice: parseFloat(value.price),
-                }
-              } else {
-                // in case no discount is found
-                let discount = value.discount || 0
-                let price = value.price / quantity
-                let originalPrice = discount + value.price
-                let computedDiscount =
-                  (discount / originalPrice).toFixed(2) * 100
-                singleSchedule = {
-                  quantity: quantity,
-                  price: price,
-                  discount: computedDiscount,
-                  totalPrice: parseFloat(value.price),
-                }
-              }
-              priceSchedules.push(singleSchedule)
-            })
-            // sort the schedules from biggest quantity to 1 ticket
-            priceSchedules = _.sortBy(priceSchedules, function(schedule) {
-              return schedule.quantity
-            }).reverse()
+            let priceSchedules = _(response.data)
+              .values()
+              .sortBy("quantity")
+              .reverse()
+              .value()
             return priceSchedules
           })
           .catch(err => {

--- a/beeline/services/data/RoutesService.js
+++ b/beeline/services/data/RoutesService.js
@@ -24,12 +24,14 @@ function transformRouteData(data) {
       }
     }
 
-    let firstTripStops = route.trips[0].tripStops
-    route.startTime = firstTripStops[0].time
-    route.startRoad = firstTripStops[0].stop.description
-    route.endTime = firstTripStops[firstTripStops.length - 1].time
-    route.endRoad = firstTripStops[firstTripStops.length - 1].stop.description
-    route.tripsByDate = _.keyBy(route.trips, trip => trip.date.getTime())
+    let firstTripStops = _.get(route, "trips[0].tripStops")
+    if (firstTripStops && firstTripStops.length) {
+      route.startTime = firstTripStops[0].time
+      route.startRoad = firstTripStops[0].stop.description
+      route.endTime = firstTripStops[firstTripStops.length - 1].time
+      route.endRoad = firstTripStops[firstTripStops.length - 1].stop.description
+      route.tripsByDate = _.keyBy(route.trips, trip => trip.date.getTime())
+    }
   })
   return data
 }

--- a/beeline/services/purchaseRoutePassService.js
+++ b/beeline/services/purchaseRoutePassService.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 import routePassTemplate from "../templates/route-pass-modal.html"
 import commonmark from "commonmark"
 import _ from "lodash"
@@ -55,17 +56,11 @@ function ModalService(
       brand: hasSavedPaymentInfo
         ? savedPaymentInfo.sources.data[0].brand
         : null,
-      last4Digtis: hasSavedPaymentInfo
+      last4Digits: hasSavedPaymentInfo
         ? savedPaymentInfo.sources.data[0].last4
         : null,
       isProcessing: null,
     }
-
-    scope.$watch("book.routePassChoice", choice => {
-      if (choice !== null) {
-        scope.book.routePassPrice = scope.book.priceSchedules[choice].totalPrice
-      }
-    })
 
     // Prompts for card and processes payment with one time stripe token.
     scope.payForRoutePass = async function() {

--- a/beeline/templates/route-pass-modal.html
+++ b/beeline/templates/route-pass-modal.html
@@ -13,9 +13,9 @@
         <div class="radios">
           <ion-radio ng-repeat="schedule in book.priceSchedules" ng-model="book.routePassChoice" class="item-text-wrap item-icon-left" icon="icon ion-ios-checkmark" ng-value="$index">
             <i class="icon ion-ios-circle-outline not-selected" ng-show="book.routePassChoice !== $index"></i>
-            <div class="priceDetails" ng-if="schedule.quantity === 1">{{schedule.quantity}} ticket (${{schedule.price | floatRoundUp | number:2}} per trip)</div>
-            <div class="priceDetails" ng-if="schedule.quantity !== 1">{{schedule.quantity}} passes (approx. ${{schedule.price | floatRoundUp | number:2}} per trip)
-              <div>save {{schedule.discount}}%</div>
+            <div class="priceDetails" ng-if="schedule.quantity === 1">{{schedule.quantity}} ticket (${{schedule.unitPrice | floatRoundUp | number:2}} per trip)</div>
+            <div class="priceDetails" ng-if="schedule.quantity !== 1">{{schedule.quantity}} passes (approx. ${{schedule.unitPrice | floatRoundUp | number:2}} per trip)
+              <div>save {{schedule.discountPercent}}%</div>
             </div>
           </ion-radio>
         </div>
@@ -58,9 +58,9 @@
           </div>
 
           <div class="buttons">
-            Total: <fancy-price value="book.routePassPrice"></fancy-price>
+            Total: <fancy-price value="book.priceSchedules[book.routePassChoice].price"></fancy-price>
             <p class="text-center" ng-if="book.hasSavedPaymentInfo">
-              This payment will be charged to your <br /><b>{{book.brand}}</b> ending in <b> {{book.last4Digtis}}</b>.
+              This payment will be charged to your <br /><b>{{book.brand}}</b> ending in <b> {{book.last4Digits}}</b>.
             </p>
             <button class="primary-button button" ng-click="proceed()"
                 ng-if="!book.hasSavedPaymentInfo"

--- a/static/templates/booking-history.html
+++ b/static/templates/booking-history.html
@@ -66,17 +66,8 @@
               <th>
                 Route
               </th>
-              <td ng-if="transaction.itemsByType.ticketSale" class="item-text-wrap">
-                {{transaction.itemsByType.ticketSale[0].route.label}}: {{transaction.itemsByType.ticketSale[0].route.from}} &mdash; {{transaction.itemsByType.ticketSale[0].route.to}}
-              </td>
-              <td ng-if="transaction.itemsByType.routeCredits" class="item-text-wrap">
-                {{transaction.itemsByType.routeCredits[0].route.label}}: {{transaction.itemsByType.routeCredits[0].route.from}} &mdash; {{transaction.itemsByType.routeCredits[0].route.to}}
-              </td>
-              <td ng-if="transaction.itemsByType.routePass" class="item-text-wrap">
-                {{transaction.itemsByType.routePass[0].route.label}}: {{transaction.itemsByType.routePass[0].route.from}} &mdash; {{transaction.itemsByType.routePass[0].route.to}}
-              </td>
-              <td ng-if="transaction.itemsByType.ticketRefund" class="item-text-wrap">
-                {{transaction.itemsByType.ticketRefund[0].route.label}}: {{transaction.itemsByType.ticketRefund[0].route.from}} &mdash; {{transaction.itemsByType.ticketRefund[0].route.to}}
+              <td ng-if="transaction.itemsByType.deal" class="item-text-wrap">
+                {{transaction.itemsByType.deal[0].route.label}}: {{transaction.itemsByType.deal[0].route.from}} &mdash; {{transaction.itemsByType.deal[0].route.to}}
               </td>
             </tr>
             <tr ng-if="transaction.itemsByType.ticketSale">

--- a/static/templates/kickstarter-summary.html
+++ b/static/templates/kickstarter-summary.html
@@ -92,7 +92,7 @@
         </div>
         <div ng-if="data.hasCreditInfo">
           <p class="text-center">
-            This payment will be charged to your <br /><b>{{data.brand}}</b> ending in <b> {{data.last4Digtis}}</b> if route is activated.
+            This payment will be charged to your <br /><b>{{data.brand}}</b> ending in <b> {{data.last4Digits}}</b> if route is activated.
           </p>
           <button class="button primary-button"
                   ng-click="createBid()"

--- a/static/templates/tab-booking-summary.html
+++ b/static/templates/tab-booking-summary.html
@@ -47,7 +47,7 @@
       <h3 class="item card-title">
         Payment
       </h3>
-      <price-calculator id="priceCalc" class="item" booking="book" price="book.price">
+      <price-calculator id="priceCalc" class="item" booking="book">
       </price-calculator>
       <div class="item-divider no-text"></div>
     </section>
@@ -89,7 +89,7 @@
       </div>
     </section>
 
-    <section class="card" 
+    <section class="card"
              ng-if="isLoggedIn && book.hasInvalidDate">
       <div class="item item-text-wrap assertive">
         You have invalid booking dates. Please re-select your dates.


### PR DESCRIPTION
* `/price_schedule` - use server-side `discountPercent` and `unitPrice` fields
* Fix typoes on the variable name `last4Digits`
* `computePriceInfo` - Use server-side transformations instead of doing them yourself
* `computePriceInfo` - Remove $scope.price, which was unused
* Guard against routes without trips or trip stops, allowing users to continue using the app even when there are badly configured routes. TODO: work out how to prevent users from clicking those
* Refactor booking history to use server-side item grouping