### PR TITLE
lite routes - use new backend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "es6": true
   },
   "rules": {
+    "func-style": ["error", "expression", { "allowArrowFunctions": true }],
     "no-unused-vars": ["error"],
     "semi": ["error", "never"],
     "comma-dangle": ["error", "always-multiline"],

--- a/beeline/common/SearchService.js
+++ b/beeline/common/SearchService.js
@@ -3,7 +3,7 @@ import _ from "lodash"
 angular.module("common").factory("SearchService", function SearchService() {
   // Helper to calculate distance in meters between a pair of coordinates
   // faster but less accurate
-  function latlngDistance(ll1, ll2) {
+  const latlngDistance = function(ll1, ll2) {
     let rr1 = [ll1[0] / 180 * Math.PI, ll1[1] / 180 * Math.PI]
     let rr2 = [ll2[0] / 180 * Math.PI, ll2[1] / 180 * Math.PI]
 
@@ -74,7 +74,7 @@ angular.module("common").factory("SearchService", function SearchService() {
     routeContainsString: function(route, string) {
       if (!string) return true
 
-      function containsIgnoreCase(s, t) {
+      const containsIgnoreCase = function(s, t) {
         if (typeof s === "string") {
           // If the search phrase (t) is more than one word, just find t in s
           // Otherwise, split s and see if any words in s start with t
@@ -94,13 +94,19 @@ angular.module("common").factory("SearchService", function SearchService() {
         containsIgnoreCase(route.notes && route.notes.description, string) ||
         containsIgnoreCase(route.schedule, string) ||
         containsIgnoreCase(route.label, string) ||
-        (route.trips[0] &&
-          (route.trips[0].tripStops.some(ts =>
-            containsIgnoreCase(ts.stop.description, string)
-          ) ||
-            route.trips[0].tripStops.some(ts =>
+        (route.trips &&
+          route.trips[0] &&
+          route.trips[0].tripStops.some(
+            ts =>
+              containsIgnoreCase(ts.stop.description, string) ||
               containsIgnoreCase(ts.stop.road, string)
-            )))
+          )) ||
+        (route.stops &&
+          route.stops.some(
+            s =>
+              containsIgnoreCase(s.description, string) ||
+              containsIgnoreCase(s.road, string)
+          ))
       )
     },
   }

--- a/beeline/common/SearchService.js
+++ b/beeline/common/SearchService.js
@@ -3,7 +3,7 @@ import _ from "lodash"
 angular.module("common").factory("SearchService", function SearchService() {
   // Helper to calculate distance in meters between a pair of coordinates
   // faster but less accurate
-  const latlngDistance = function(ll1, ll2) {
+  const latlngDistance = function latlngDistance(ll1, ll2) {
     let rr1 = [ll1[0] / 180 * Math.PI, ll1[1] / 180 * Math.PI]
     let rr2 = [ll2[0] / 180 * Math.PI, ll2[1] / 180 * Math.PI]
 
@@ -74,7 +74,7 @@ angular.module("common").factory("SearchService", function SearchService() {
     routeContainsString: function(route, string) {
       if (!string) return true
 
-      const containsIgnoreCase = function(s, t) {
+      const containsIgnoreCase = function containsIgnoreCase(s, t) {
         if (typeof s === "string") {
           // If the search phrase (t) is more than one word, just find t in s
           // Otherwise, split s and see if any words in s start with t

--- a/beeline/controllers/LiteDetailController.js
+++ b/beeline/controllers/LiteDetailController.js
@@ -28,6 +28,30 @@ export default [
     $state
   ) {
     // ------------------------------------------------------------------------
+    // Helper Functions
+    // ------------------------------------------------------------------------
+    /**
+     * Send fake trip objects to MapService, to retrieve pings and statuses
+     */
+    const sendTripsToMapView = function sendTripsToMapView() {
+      const dailyTripIds = $scope.book.dailyTripIds
+      if (dailyTripIds && dailyTripIds.length > 0) {
+        MapService.emit("ping-trips", dailyTripIds.map(id => ({ id })))
+      }
+    }
+
+    /**
+     * Refresh trip information
+     * @param {Object} tripInfo - a payload from MapService, obtained from
+     * the backend
+     */
+    const updateTripInfo = function updateTripInfo(tripInfo) {
+      $scope.disp.hasTrackingData = tripInfo.hasTrackingData
+      $scope.disp.statusMessages = tripInfo.statusMessages
+      $scope.$digest()
+    }
+
+    // ------------------------------------------------------------------------
     // stateParams
     // ------------------------------------------------------------------------
     let label = $stateParams.label
@@ -242,30 +266,6 @@ export default [
       } finally {
         $scope.book.waitingForSubscriptionResult = false
       }
-    }
-
-    // ------------------------------------------------------------------------
-    // Helper Functions
-    // ------------------------------------------------------------------------
-    /**
-     * Send fake trip objects to MapService, to retrieve pings and statuses
-     */
-    function sendTripsToMapView() {
-      const dailyTripIds = $scope.book.dailyTripIds
-      if (dailyTripIds && dailyTripIds.length > 0) {
-        MapService.emit("ping-trips", dailyTripIds.map(id => ({ id })))
-      }
-    }
-
-    /**
-     * Refresh trip information
-     * @param {Object} tripInfo - a payload from MapService, obtained from
-     * the backend
-     */
-    function updateTripInfo(tripInfo) {
-      $scope.disp.hasTrackingData = tripInfo.hasTrackingData
-      $scope.disp.statusMessages = tripInfo.statusMessages
-      $scope.$digest()
     }
   },
 ]

--- a/beeline/controllers/LiteMapViewController.js
+++ b/beeline/controllers/LiteMapViewController.js
@@ -18,6 +18,29 @@ export default [
     MapViewFactory
   ) {
     // ------------------------------------------------------------------------
+    // Helper functions
+    // ------------------------------------------------------------------------
+    /**
+     * Request driver pings for the given trip
+     */
+    const pingLoop = async function pingLoop() {
+      const recentTimeBound = 5 * 60000
+      await MapViewFactory.pingLoop($scope, recentTimeBound)()
+
+      // to mark no tracking data if no ping or pings are too old
+      // isRecent could be undefined(no pings) or false (pings are out-dated)
+      $scope.hasTrackingData = _.any(
+        $scope.mapObject.allRecentPings,
+        "isRecent"
+      )
+      let tripInfo = {
+        hasTrackingData: $scope.hasTrackingData,
+        statusMessages: $scope.mapObject.statusMessages.join(" "),
+      }
+      MapService.emit("tripInfo", tripInfo)
+    }
+
+    // ------------------------------------------------------------------------
     // stateParams
     // ------------------------------------------------------------------------
     let routeLabel = $stateParams.label ? $stateParams.label : null
@@ -46,28 +69,5 @@ export default [
       $scope.mapObject.stops = route.stops
       SharedVariableService.setStops(route.stops)
     })
-
-    // ------------------------------------------------------------------------
-    // Helper functions
-    // ------------------------------------------------------------------------
-    /**
-     * Request driver pings for the given trip
-     */
-    async function pingLoop() {
-      const recentTimeBound = 5 * 60000
-      await MapViewFactory.pingLoop($scope, recentTimeBound)()
-
-      // to mark no tracking data if no ping or pings are too old
-      // isRecent could be undefined(no pings) or false (pings are out-dated)
-      $scope.hasTrackingData = _.any(
-        $scope.mapObject.allRecentPings,
-        "isRecent"
-      )
-      let tripInfo = {
-        hasTrackingData: $scope.hasTrackingData,
-        statusMessages: $scope.mapObject.statusMessages.join(" "),
-      }
-      MapService.emit("tripInfo", tripInfo)
-    }
   },
 ]

--- a/beeline/controllers/LiteMapViewController.js
+++ b/beeline/controllers/LiteMapViewController.js
@@ -43,13 +43,8 @@ export default [
             $scope.mapObject.routePath = []
           })
       }
-      const trips = _.sortBy(route.trips, trip => {
-        return trip.date
-      })
-      let nextTrips = trips.filter(trip => trip.date === trips[0].date)
-      const liteTripStops = LiteRoutesService.computeLiteStops(nextTrips)
-      $scope.mapObject.stops = liteTripStops
-      SharedVariableService.setStops(liteTripStops)
+      $scope.mapObject.stops = route.stops
+      SharedVariableService.setStops(route.stops)
     })
 
     // ------------------------------------------------------------------------

--- a/beeline/controllers/LiteMoreInfoController.js
+++ b/beeline/controllers/LiteMoreInfoController.js
@@ -1,3 +1,5 @@
+import { htmlFrom } from "../shared/util"
+
 export default [
   "$scope",
   "$stateParams",
@@ -9,7 +11,6 @@ export default [
     // ------------------------------------------------------------------------
     let companyId = $stateParams.companyId
     let label = $stateParams.label
-
     // ------------------------------------------------------------------------
     // Data Initialization
     // ------------------------------------------------------------------------
@@ -24,9 +25,7 @@ export default [
     // ------------------------------------------------------------------------
     LiteRoutesService.fetchLiteRoute($scope.data.label).then(liteRoute => {
       $scope.data.liteRoute = liteRoute[$scope.data.label]
-      RoutesService.getRouteFeatures($scope.data.liteRoute.id).then(data => {
-        $scope.data.features = data
-      })
+      $scope.data.features = htmlFrom(liteRoute[$scope.data.label].features)
     })
   },
 ]

--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -87,6 +87,46 @@ export default [
     // ------------------------------------------------------------------------
     // Watchers
     // ------------------------------------------------------------------------
+    const autoComplete = function autoComplete() {
+      if (!$scope.data.queryText) {
+        $scope.data.placeQuery = null
+        $scope.data.isFiltering = false
+        $scope.$digest()
+        return
+      }
+
+      // show the spinner
+      $scope.data.isFiltering = true
+      $scope.$digest()
+
+      // default 'place' object only has 'queryText' but no geometry
+      let place = { queryText: $scope.data.queryText }
+      SearchEventService.emit("search-item", $scope.data.queryText)
+
+      // Reset routes, crowdstartRoutes and liteRoutes here because they are
+      // used to determine whether we do a place query (see watchGroup with
+      // all 3)
+      // If we don't reset, we could end up with the case where the criteria
+      // is applied to the wrong version of them
+      // E.g.
+      // 1. User makes one search. App completely finishes all filtering.
+      // 2. User makes another search.
+      // 3. First time we enter watchgroup for routes + crowdstartRoutes, only
+      //    only one of them has changed. WLOG assume it is routes.
+      // 4. Then routes is filtered from the new search, while crowdstartRoutes
+      //    is filtered from the old search.
+      // 5. Then the check (routes.length + crowdstartRoutes.length +
+      //    liteRoutes.length> 0) is using the wrong version of crowdstartRoutes
+      //    and could result in us doing unnecessary place queries.
+      //
+      // Resetting to null also has the benefit that the check whether we do
+      // place queries is only done once.
+      $scope.data.routes = null
+      $scope.data.crowdstartRoutes = null
+      $scope.data.liteRoutes = null
+      $scope.data.placeQuery = place
+      $scope.$digest()
+    }
 
     $scope.$watch(
       "data.queryText",
@@ -364,7 +404,7 @@ export default [
     $scope.$watchGroup(
       ["data.routes", "data.crowdstartRoutes", "data.liteRoutes"],
       ([routes, crowdstartRoutes, liteRoutes]) => {
-        async function handlePlaceQuery() {
+        const handlePlaceQuery = async function handlePlaceQuery() {
           // Important comments in the autoComplete function
           if (!routes || !crowdstartRoutes || !liteRoutes) return
           // Criteria for making a place query
@@ -390,7 +430,7 @@ export default [
           $scope.$digest()
         }
 
-        async function stopFilteringAfterDelay() {
+        const stopFilteringAfterDelay = async function stopFilteringAfterDelay() {
           await sleep(500)
           $scope.data.isFiltering = false
           $scope.$digest()
@@ -468,6 +508,14 @@ export default [
       }
     )
 
+    const routesAreLoaded = function routesAreLoaded() {
+      return !!(
+        $scope.data.routes &&
+        $scope.data.liteRoutes &&
+        $scope.data.crowdstartRoutes
+      )
+    }
+
     // call $anchorScroll only if all data loaded and there is $location.hash()
     $scope.$watch(
       () => routesAreLoaded(),
@@ -542,58 +590,6 @@ export default [
         "https://www.beeline.sg/suggest.html#" +
           querystring.stringify({ referrer: appName }),
         "_system"
-      )
-    }
-
-    // ------------------------------------------------------------------------
-    // Helper Functions
-    // ------------------------------------------------------------------------
-    function autoComplete() {
-      if (!$scope.data.queryText) {
-        $scope.data.placeQuery = null
-        $scope.data.isFiltering = false
-        $scope.$digest()
-        return
-      }
-
-      // show the spinner
-      $scope.data.isFiltering = true
-      $scope.$digest()
-
-      // default 'place' object only has 'queryText' but no geometry
-      let place = { queryText: $scope.data.queryText }
-      SearchEventService.emit("search-item", $scope.data.queryText)
-
-      // Reset routes, crowdstartRoutes and liteRoutes here because they are
-      // used to determine whether we do a place query (see watchGroup with
-      // all 3)
-      // If we don't reset, we could end up with the case where the criteria
-      // is applied to the wrong version of them
-      // E.g.
-      // 1. User makes one search. App completely finishes all filtering.
-      // 2. User makes another search.
-      // 3. First time we enter watchgroup for routes + crowdstartRoutes, only
-      //    only one of them has changed. WLOG assume it is routes.
-      // 4. Then routes is filtered from the new search, while crowdstartRoutes
-      //    is filtered from the old search.
-      // 5. Then the check (routes.length + crowdstartRoutes.length +
-      //    liteRoutes.length> 0) is using the wrong version of crowdstartRoutes
-      //    and could result in us doing unnecessary place queries.
-      //
-      // Resetting to null also has the benefit that the check whether we do
-      // place queries is only done once.
-      $scope.data.routes = null
-      $scope.data.crowdstartRoutes = null
-      $scope.data.liteRoutes = null
-      $scope.data.placeQuery = place
-      $scope.$digest()
-    }
-
-    function routesAreLoaded() {
-      return !!(
-        $scope.data.routes &&
-        $scope.data.liteRoutes &&
-        $scope.data.crowdstartRoutes
       )
     }
   },

--- a/beeline/directives/dailyTripsBroker.js
+++ b/beeline/directives/dailyTripsBroker.js
@@ -1,5 +1,4 @@
 import { SafeScheduler } from "../SafeScheduler"
-import _ from "lodash"
 
 // since it's broker, we allow 2-way binding for now and
 // view update the data model which controll relies on
@@ -13,13 +12,13 @@ angular.module("beeline").directive("dailyTripsBroker", [
       template: "",
       scope: {
         tripLabel: "<",
-        dailyTrips: "=",
+        dailyTripIds: "=",
         inServiceWindow: "=",
       },
       link: function(scope, element, attributes) {
         let timeout
 
-        scope.dailyTrips = null
+        scope.dailyTripIds = null
 
         scope.$watch("tripLabel", label => {
           if (timeout) timeout.stop()
@@ -48,20 +47,7 @@ angular.module("beeline").directive("dailyTripsBroker", [
           return LiteRoutesService.fetchLiteRoute(label, true).then(
             response => {
               let route = response[scope.tripLabel]
-
-              let now = new Date()
-              let todayTrips = route.trips.filter(
-                trip =>
-                  trip.isRunning &&
-                  new Date(trip.date).getTime() ==
-                    Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
-              )
-
-              scope.dailyTrips = _.sortBy(
-                todayTrips,
-                trip => new Date(trip.tripStops[0].time)
-              )
-
+              scope.dailyTripIds = route.tripIds
               scheduleServiceWindowChanges(route)
             }
           )

--- a/beeline/directives/priceCalculator/priceCalculator.js
+++ b/beeline/directives/priceCalculator/priceCalculator.js
@@ -67,7 +67,7 @@ angular.module("beeline").directive("priceCalculator", [
           /**
            * Recompute prices whenever relevant inputs change
            */
-          async function recomputePrices() {
+          const recomputePrices = async function recomputePrices() {
             assert($scope.booking.routeId)
             if (!$scope.booking.route) {
               $scope.booking.route = await RoutesService.getRoute(

--- a/beeline/directives/routeItem/liteRoute.html
+++ b/beeline/directives/routeItem/liteRoute.html
@@ -7,13 +7,13 @@
     {{ route.notes.description }}
   </route-item-description>
   <route-item-start-time>
-    {{ route | routeStartTime | formatTime:true }}
+    {{ route.startTime | formatTime:true }}
   </route-item-start-time>
   <route-item-start-location>
     {{ route.from }}
   </route-item-start-location>
   <route-item-end-time>
-    {{ route | routeEndTime | formatTime:true }}
+    {{ route.endTime | formatTime:true }}
   </route-item-end-time>
   <route-item-end-location>
     {{ route.to }}

--- a/beeline/directives/routesList/routesList.html
+++ b/beeline/directives/routesList/routesList.html
@@ -16,7 +16,7 @@
 
   <!-- Available Lite Routes Section -->
   <ion-item
-    ng-repeat="route in data.liteRoutes | limitTo:10 track by route.id"
+    ng-repeat="route in data.liteRoutes | limitTo:10 track by route.label"
     ui-sref="tabs.lite-detail({ label: route.label })"
   >
     <lite-route route="route"></lite-route>

--- a/beeline/services/data/LiteRouteSubscriptionService.js
+++ b/beeline/services/data/LiteRouteSubscriptionService.js
@@ -24,7 +24,7 @@ angular.module("beeline").factory("LiteRouteSubscriptionService", [
           }
           return (LiteRouteSubscriptionCache = RequestService.beeline({
             method: "GET",
-            url: "/liteRoutes/subscriptions",
+            url: "/routes/lite/subscriptions",
           }).then(response => {
             liteRouteSubscriptionsSummary = response.data.map(
               subs => subs.routeLabel

--- a/beeline/services/data/LiteRoutesService.js
+++ b/beeline/services/data/LiteRoutesService.js
@@ -1,10 +1,11 @@
+/* eslint-disable require-jsdoc */
 // get lite routes
 // format lite routes with starting time, ending time, no. of timings/trips per day
 // retrieve lists of trips running for certain lite route on certain date
 // driver pings for list of trips running for this route
 // subscriptions for certain lite route ( this may go to tickets service)
 import querystring from "querystring"
-import _ from "lodash"
+import moment from "moment"
 import assert from "assert"
 
 angular.module("beeline").factory("LiteRoutesService", [
@@ -21,181 +22,67 @@ angular.module("beeline").factory("LiteRoutesService", [
     let shouldRefreshLiteTickets = false
     let liteRoutes = null
 
-    function transformTime(liteRoutesByLabel) {
-      for (let label in liteRoutesByLabel) {
-        if ({}.hasOwnProperty.call(liteRoutesByLabel, label)) {
-          let liteRoute = liteRoutesByLabel[label]
-          // no starting time and ending time
-          if (!liteRoute.trips) {
-            liteRoute.startTime = null
-            liteRoute.endTime = null
-            return
-          }
-          let minTripDate = _.min(liteRoute.trips.map(trip => trip.date))
-          let tripAsMinTripDate = liteRoute.trips.filter(
-            trip => trip.date === minTripDate
-          )
-          let tripStops = _.flatten(
-            tripAsMinTripDate.map(trip => trip.tripStops || [])
-          )
-          let allStopTimes = tripStops.map(stop => stop.time).sort()
-          liteRoute.startTime = allStopTimes[0]
-          liteRoute.endTime = allStopTimes[allStopTimes.length - 1]
-        }
-      }
-    }
-
-    // TODO the same label lite route all data fileds should be the same except trips
-    // otherwise reduce make no sense
-    function transformLiteRouteData(data) {
-      let liteRoutesByLabel = _.reduce(
-        data,
-        function(result, value, key) {
-          let label = value.label
-          if (result[label] && (result[label].trips || value.trips)) {
-            result[label].trips = result[label].trips.concat(value.trips)
-          } else {
-            result[label] = value
-            // mark isSubscribed as false
-            result[label].isSubscribed = false
-          }
-          return result
-        },
-        {}
-      )
-      transformTime(liteRoutesByLabel)
-      // ignor the startingTime and endTime for now
-      return liteRoutesByLabel
-    }
-
-    // consolidate tripstops for lite route
-    // aggregate stop time for stops
-    function computeLiteStops(trips) {
-      let tripStops = _.map(trips, trip => {
-        return trip.tripStops
-      })
-      let allTripStops = _.flatten(tripStops)
-
-      let boardStops = _.groupBy(allTripStops, function(tripStop) {
-        return tripStop.stop.id
-      })
-      let newStops = []
-      for (let stopId in boardStops) {
-        if ({}.hasOwnProperty.call(boardStops, stopId)) {
-          let stop = boardStops[stopId][0].stop
-          stop.canBoard = boardStops[stopId][0].canBoard
-          let timeArray = _.map(boardStops[stopId], stop => {
-            return stop.time
-          })
-          let sortedTime = _(timeArray)
-            .uniq()
-            .sort()
-            .value()
-          newStops.push(_.extend({ time: sortedTime }, stop))
-        }
-      }
-      return newStops
-    }
-
     // Retrive the data on all lite routes
     // But limits the amount of data retrieved
     // getRoutes() now returns a list of routes, but with very limited
     // trip data (limited to 5 trips, no path)
-    function fetchLiteRoutes(ignoreCache, options) {
-      if (liteRoutesCache && !ignoreCache && !options) return liteRoutesCache
+    function fetchLiteRoutes(ignoreCache) {
+      if (liteRoutesCache && !ignoreCache) {
+        return liteRoutesCache
+      }
 
-      let url = "/routes?"
-
-      // Start at midnight to avoid cut trips in the middle
-      // FIXME: use date-based search instead
-      let startDate = new Date()
-      startDate.setHours(3, 0, 0, 0, 0)
-
-      let finalOptions = _.assign(
-        {
-          startDate: startDate.getTime(),
-          includePath: true,
-          includeTrips: true,
-          limitTrips: 5,
-          tags: JSON.stringify(["lite"]),
-        },
-        options,
-        p.transportCompanyId ? { transportCompanyId: p.transportCompanyId } : {}
-      )
-
-      url += querystring.stringify(finalOptions)
+      let finalOptions = p.transportCompanyId
+        ? { transportCompanyId: p.transportCompanyId }
+        : {}
 
       let liteRoutesPromise = RequestService.beeline({
         method: "GET",
-        url: url,
-      }).then(function(response) {
-        // Checking that we have trips, so that users of it don't choke
-        // on trips[0]
-        liteRoutes = response.data.filter(r => r.trips && r.trips.length)
-        liteRoutes = transformLiteRouteData(liteRoutes)
+        url: "/routes/lite?" + querystring.stringify(finalOptions),
+      }).then(response => {
+        liteRoutes = response.data
         return liteRoutes
       })
 
       // Cache the promise -- prevents two requests from being
       // in flight together
-      if (!options) {
-        liteRoutesCache = liteRoutesPromise
-      }
+      liteRoutesCache = liteRoutesPromise
       return liteRoutesPromise
     }
 
-    function fetchLiteRoute(liteRouteLabel, ignoreCache, options) {
+    function fetchLiteRoute(liteRouteLabel, ignoreCache) {
       assert.equal(typeof liteRouteLabel, "string")
 
-      if (!ignoreCache && !options && lastLiteRouteLabel === liteRouteLabel) {
+      if (!ignoreCache && lastLiteRouteLabel === liteRouteLabel) {
         return lastLiteRoutePromise
       }
-
-      let startDate = new Date()
-      startDate.setHours(3, 0, 0, 0, 0)
-
-      let finalOptions = _.assign(
-        {
-          startDate: startDate.getTime(),
-          includeTrips: true,
-          tags: JSON.stringify(["lite"]),
-          label: liteRouteLabel,
-          includePath: true,
-        },
-        options,
-        p.transportCompanyId ? { transportCompanyId: p.transportCompanyId } : {}
-      )
-
-      let url = "/routes?"
-      url += querystring.stringify(finalOptions)
 
       lastLiteRouteLabel = liteRouteLabel
       return (lastLiteRoutePromise = RequestService.beeline({
         method: "GET",
-        url: url,
+        url:
+          "/routes/lite?" +
+          querystring.stringify({
+            label: liteRouteLabel,
+            startDate: moment().format("YYYY-MM-DD"),
+            includePath: true,
+          }),
       })
-        .then(function(response) {
-          let liteRouteData = transformLiteRouteData(response.data)
-          return liteRouteData
-        })
+        .then(response => response.data)
         .catch(err => {
           console.error(err)
         }))
     }
 
     return {
-      fetchLiteRoutes: fetchLiteRoutes,
-      fetchLiteRoute: fetchLiteRoute,
+      fetchLiteRoutes,
+      fetchLiteRoute,
       getLiteRoutes: function() {
         return liteRoutes
       },
       subscribeLiteRoute: function(liteRouteLabel) {
         let subscribePromise = RequestService.beeline({
           method: "POST",
-          url: "/liteRoutes/subscriptions",
-          data: {
-            routeLabel: liteRouteLabel,
-          },
+          url: `/routes/lite/${liteRouteLabel}/subscription`,
         }).then(function(response) {
           shouldRefreshLiteTickets = true
           if (response.data) {
@@ -212,7 +99,7 @@ angular.module("beeline").factory("LiteRoutesService", [
       unsubscribeLiteRoute: function(liteRouteLabel) {
         let unsubscribePromise = RequestService.beeline({
           method: "DELETE",
-          url: "/liteRoutes/subscriptions/" + liteRouteLabel,
+          url: `/routes/lite/${liteRouteLabel}/subscription`,
         }).then(function(response) {
           shouldRefreshLiteTickets = true
           if (response.data) {
@@ -237,8 +124,6 @@ angular.module("beeline").factory("LiteRoutesService", [
       clearShouldRefreshLiteTickets: function() {
         shouldRefreshLiteTickets = false
       },
-      transformLiteRouteData: transformLiteRouteData,
-      computeLiteStops: computeLiteStops,
     }
   },
 ])

--- a/beeline/services/data/LiteRoutesService.js
+++ b/beeline/services/data/LiteRoutesService.js
@@ -26,7 +26,7 @@ angular.module("beeline").factory("LiteRoutesService", [
     // But limits the amount of data retrieved
     // getRoutes() now returns a list of routes, but with very limited
     // trip data (limited to 5 trips, no path)
-    function fetchLiteRoutes(ignoreCache) {
+    const fetchLiteRoutes = function fetchLiteRoutes(ignoreCache) {
       if (liteRoutesCache && !ignoreCache) {
         return liteRoutesCache
       }
@@ -49,7 +49,10 @@ angular.module("beeline").factory("LiteRoutesService", [
       return liteRoutesPromise
     }
 
-    function fetchLiteRoute(liteRouteLabel, ignoreCache) {
+    const fetchLiteRoute = function fetchLiteRoute(
+      liteRouteLabel,
+      ignoreCache
+    ) {
       assert.equal(typeof liteRouteLabel, "string")
 
       if (!ignoreCache && lastLiteRouteLabel === liteRouteLabel) {

--- a/static/templates/tab-lite-detail.html
+++ b/static/templates/tab-lite-detail.html
@@ -5,7 +5,7 @@
   </ion-nav-buttons>
   <ion-content scroll="true">
     <daily-trips-broker trip-label="book.route.label"
-                 daily-trips="book.todayTrips"
+                 daily-trip-ids="book.dailyTripIds"
                  in-service-window="book.inServiceWindow">
     </daily-trips-broker>
     <form class="stops-form" name="stopsForm">


### PR DESCRIPTION
* Point at the `/routes/lite` family of endpoints for lite routes
* Clear out all code relating to trips
* Ensure that MapService is fed needed trip ids for pings and statuses