### PR TITLE
Route detail improvements

### DIFF
--- a/beeline/directives/countdown.js
+++ b/beeline/directives/countdown.js
@@ -18,7 +18,7 @@ angular.module("beeline").directive("countdown", [
         let stopTime // so that we can cancel the time updates
 
         // used to update the UI
-        function updateTime() {
+        const updateTime = function updateTime() {
           scope.minsBeforeClose = moment(scope.boardTime).diff(
             moment(Date.now()),
             "minutes"
@@ -29,6 +29,7 @@ angular.module("beeline").directive("countdown", [
           if (bt && !stopTime) {
             scope.bookingEnds = false
             stopTime = $interval(updateTime, 100 * 30)
+            updateTime()
           }
         })
 

--- a/beeline/directives/routesList/yourRoutesList.html
+++ b/beeline/directives/routesList/yourRoutesList.html
@@ -10,16 +10,16 @@
     </button>
   </div>
 
-  <div class="item item-divider" ng-if="data.activatedCrowdstartRoutes.length > 0
+  <div class="item item-divider" ng-if="data.routesWithRidesRemaining.length > 0
                      || data.recentRoutes.length > 0">
     Booking Routes
   </div>
   <ion-item
-    ng-repeat="route in data.activatedCrowdstartRoutes | limitTo:10 track by route.id"
+    ng-repeat="route in data.routesWithRidesRemaining | limitTo:10 track by route.id"
     ui-sref="tabs.route-detail({
       routeId: route.id
     })"
-    ng-if="data.activatedCrowdstartRoutes.length > 0"
+    ng-if="data.routesWithRidesRemaining.length > 0"
   >
     <regular-route route="route"></regular-route>
   </ion-item>

--- a/beeline/services/data/RoutesService.js
+++ b/beeline/services/data/RoutesService.js
@@ -12,7 +12,7 @@ import assert from "assert"
  * @return {Object}
  *   the response, with time and locations flattened into it from the trip stops
  */
-function transformRouteData(data) {
+const transformRouteData = function transformRouteData(data) {
   _(data).each(function(route) {
     for (let trip of route.trips) {
       assert.equal(typeof trip.date, "string")
@@ -68,7 +68,7 @@ angular.module("beeline").factory("RoutesService", [
     let routeToRidesRemainingMap
     let routesWithRoutePassPromise
     let routesWithRoutePass
-    let activatedKickstarterRoutes
+    let routesWithRidesRemaining
     let routeToRoutePassTagsPromise = null
     let routeToRoutePassTags = null
 
@@ -385,7 +385,7 @@ angular.module("beeline").factory("RoutesService", [
       // output:
       // - promise containing all routes, modified with ridesRemaining property
       // side effect:
-      // - updates activatedKickstarterRoutes: array containing only those routes with
+      // - updates routesWithRidesRemaining: array containing only those routes with
       // ridesRemaining property
       // - updates routesWithRoutePass: array containing all avaialable routes,
       // modifying those with route credits remaining with a ridesRemaining property
@@ -406,7 +406,7 @@ angular.module("beeline").factory("RoutesService", [
                       : null
                   return clone
                 })
-                activatedKickstarterRoutes = routesWithRoutePass.filter(
+                routesWithRidesRemaining = routesWithRoutePass.filter(
                   route => route.id in routeToRidesRemainingMap
                 )
 
@@ -430,8 +430,8 @@ angular.module("beeline").factory("RoutesService", [
       // Returns array containing only those routes with
       // ridesRemaining property
       // Updated by: fetchRoutesWithRoutePass
-      getActivatedKickstarterRoutes: function() {
-        return activatedKickstarterRoutes
+      getRoutesWithRidesRemaining: function() {
+        return routesWithRidesRemaining
       },
 
       // Returns promise containing a map of all routeId to their corresponding tags

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   ],
   "scripts": {
     "build": "node scripts/build.js",
+    "build-watch": "node scripts/build.js --watch",
     "clean": "shx rm -rf www/",
     "deploy": "node scripts/deploy.js",
     "dev": "node scripts/dev.js",
@@ -109,6 +110,7 @@
     "install-ios": "ionic cordova platform remove ios && ionic cordova platform add ios",
     "dev-android": "node scripts/dev-android.js",
     "start": "http-server -c-1 www/",
+    "watch": "npm run start & npm run build-watch",
     "lint": "node scripts/lint.js",
     "prettier": "node scripts/prettier.js",
     "prettier-lint": "bash scripts/prettier-lint.sh"


### PR DESCRIPTION
* Booking countdown - Ensure that updateTime is invoked on load
* add `npm run watch` - which starts a server and webpack-watch to allow incremental builds for dev testing
* rename activatedKickstarterRoutes to the more appropriate routesWithRidesRemaining
* if a route is recently booked, filter it out of routesWithRidesRemaining. We do this since
we know the stops that a user recently booked and want to populate that information, which
is more important than knowing that a user has so many remaining route passes for a route