### PR TITLE
 Implement getPrivateCrowdstartById, use in getCrowdstartById

### DIFF
--- a/beeline/controllers/KickstarterCommitController.js
+++ b/beeline/controllers/KickstarterCommitController.js
@@ -37,7 +37,8 @@ export default [
         () => KickstarterService.getCrowdstartById($scope.book.routeId),
         () => KickstarterService.getBidInfo($scope.book.routeId),
       ],
-      ([route, bid]) => {
+      async ([routePromise, bid]) => {
+        const route = await routePromise
         if (!route) return
         $scope.book.route = route
         if (!bid) return

--- a/beeline/controllers/KickstarterDetailController.js
+++ b/beeline/controllers/KickstarterDetailController.js
@@ -59,7 +59,8 @@ export default [
     // ------------------------------------------------------------------------
     $scope.$watch(
       () => KickstarterService.getCrowdstartById($scope.book.routeId),
-      route => {
+      async routePromise => {
+        const route = await routePromise
         if (!route) return
         $scope.book.route = route
         $scope.book.bidOptions = route.notes.tier
@@ -80,7 +81,8 @@ export default [
         () => UserService.getUser(),
         () => KickstarterService.getCrowdstartById($scope.book.routeId),
       ],
-      ([user, route]) => {
+      async ([user, routePromise]) => {
+        const route = await routePromise
         if (!user || !route) return
 
         // Figure out if user has bidded on this crowdstart route

--- a/beeline/controllers/KickstarterRecapController.js
+++ b/beeline/controllers/KickstarterRecapController.js
@@ -66,7 +66,8 @@ export default [
         () => KickstarterService.getBidInfo($scope.book.routeId),
         () => RoutesService.getRoutePasses($scope.book.creditTag),
       ],
-      ([route, bid, passes]) => {
+      async ([routePromise, bid, passes]) => {
+        const route = await routePromise
         if (!route) return
         $scope.book.route = route
         // Summarizes the stops from trips by comparing their stop location

--- a/beeline/controllers/KickstarterSummaryController.js
+++ b/beeline/controllers/KickstarterSummaryController.js
@@ -65,7 +65,8 @@ export default [
     // ------------------------------------------------------------------------
     $scope.$watch(
       () => KickstarterService.getCrowdstartById($scope.book.routeId),
-      route => {
+      async routePromise => {
+        const route = await routePromise
         if (!route) return
         $scope.book.route = route
 
@@ -117,7 +118,8 @@ export default [
         () => UserService.getUser(),
         () => KickstarterService.getCrowdstartById($scope.book.routeId),
       ],
-      ([user, route]) => {
+      async ([user, routePromise]) => {
+        const route = await routePromise
         if (!user || !route) return
 
         // Figure out if user has bidded on this crowdstart route

--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -206,19 +206,18 @@ export default [
         () => KickstarterService.getBids(),
         () => KickstarterService.getKickstarterRoutesById(),
       ],
-      ([bids, kickstarterRoutesById]) => {
+      async ([bids, kickstarterRoutesById]) => {
         if (!bids || !kickstarterRoutesById) return
 
-        $scope.data.backedCrowdstartRoutes = bids
-          .map(bid => {
-            return KickstarterService.getCrowdstartById(bid.routeId)
-          })
-          .filter(
-            route =>
-              (!route.passExpired && route.isActived) ||
-              !route.isExpired ||
-              !route.is7DaysOld
-          )
+        const crowdstarts = await Promise.all(
+          bids.map(bid => KickstarterService.getCrowdstartById(bid.routeId))
+        )
+        $scope.data.backedCrowdstartRoutes = crowdstarts.filter(
+          route =>
+            (!route.passExpired && route.isActived) ||
+            !route.isExpired ||
+            !route.is7DaysOld
+        )
       }
     )
 

--- a/beeline/services/data/KickstarterService.js
+++ b/beeline/services/data/KickstarterService.js
@@ -134,27 +134,7 @@ angular.module("beeline").service("KickstarterService", [
     let kickstarterRoutesById = null
     let nearbyKickstarterRoutesById = null
 
-    UserService.userEvents.on("userChanged", () => {
-      fetchBids(true)
-      // to load route credits
-      RoutesService.fetchRoutePassCount(true)
-    })
-
-    // first load
-    // every 1 hour should reload kickstarter information
-    let timeout = new SafeInterval(refresh, 1000 * 60 * 60, 1000 * 60)
-
-    function refresh() {
-      return Promise.all([
-        fetchKickstarterRoutes(true),
-        fetchBids(true),
-        fetchNearbyKickstarterIds(),
-      ])
-    }
-
-    timeout.start()
-
-    function fetchBids(ignoreCache) {
+    const fetchBids = function fetchBids(ignoreCache) {
       if (UserService.getUser()) {
         if (bidsCache && !ignoreCache) return bidsCache
         return (bidsCache = RequestService.beeline({
@@ -178,7 +158,9 @@ angular.module("beeline").service("KickstarterService", [
       }
     }
 
-    function fetchKickstarterRoutes(ignoreCache) {
+    const fetchKickstarterRoutes = function fetchKickstarterRoutes(
+      ignoreCache
+    ) {
       if (kickstarterRoutesCache && !ignoreCache) return kickstarterRoutesCache
       let url = "/crowdstart/status"
       if (p.transportCompanyId) {
@@ -197,7 +179,9 @@ angular.module("beeline").service("KickstarterService", [
       }))
     }
 
-    function getLocationPromise(enableHighAccuracy = false) {
+    const getLocationPromise = function getLocationPromise(
+      enableHighAccuracy = false
+    ) {
       return new Promise((resolve, reject) => {
         navigator.geolocation.getCurrentPosition(
           success => resolve(success),
@@ -207,7 +191,7 @@ angular.module("beeline").service("KickstarterService", [
       })
     }
 
-    async function fetchNearbyKickstarterIds() {
+    const fetchNearbyKickstarterIds = async function fetchNearbyKickstarterIds() {
       let locationOrNull = null
       try {
         await DevicePromise
@@ -272,6 +256,25 @@ angular.module("beeline").service("KickstarterService", [
           .value())
       })
     }
+
+    UserService.userEvents.on("userChanged", () => {
+      fetchBids(true)
+      // to load route credits
+      RoutesService.fetchRoutePassCount(true)
+    })
+
+    const refresh = function refresh() {
+      return Promise.all([
+        fetchKickstarterRoutes(true),
+        fetchBids(true),
+        fetchNearbyKickstarterIds(),
+      ])
+    }
+
+    // first load
+    // every 1 hour should reload kickstarter information
+    let timeout = new SafeInterval(refresh, 1000 * 60 * 60, 1000 * 60)
+    timeout.start()
 
     return {
       // all crowdstart routes


### PR DESCRIPTION
If a crowdstart route is not available in the usual dump from `/crowdstart/status`,
we assume it is a private one, and look up the route and bid info, and then transform
in the usual manner. This is implemented in `getPrivateCrowdstartById`.

That function returns a promise, the least invasive approach to integrating this into
`getCrowdstartById` (see the parent commit). Further, to prevent Angular from being
extremely confused when polling the retval of `getCrowdstartById`, and thinking that it is constantly changing (because Promises appear to be globally unique), we remember the
last looked up route id, and ensure we return the last promise created, if the route ids match

Given that private crowdstarts are only invoked if the user actually knows the URL, this should
not prove to have too much impact to regular usage

TODO: Figure out if there’s an even better way to wrap this up. Odds seem pretty low here.