### PR TITLE
KickstarterService.updateAfterBid - Update route, rather than looking it up again

### DIFF
--- a/beeline/services/data/KickstarterService.js
+++ b/beeline/services/data/KickstarterService.js
@@ -357,7 +357,7 @@ angular.module("beeline").service("KickstarterService", [
             price: bidPrice,
           },
         }).then(response => {
-          updateAfterBid(kickstarterRoutesById[route.id], bidPrice)
+          updateAfterBid(route, bidPrice)
           kickstarterSummary = kickstarterSummary.concat([
             {
               routeId: route.id,


### PR DESCRIPTION
This allows us to update statuses even for private crowdstarts, which are not held
in kickstarterRoutesById