### PR TITLE
Fix bug with booking button time cut off

### DIFF
--- a/beeline/directives/countdown.js
+++ b/beeline/directives/countdown.js
@@ -21,7 +21,8 @@ angular.module("beeline").directive("countdown", [
         const updateTime = function updateTime() {
           scope.minsBeforeClose = moment(scope.boardTime).diff(
             moment(Date.now()),
-            "minutes"
+            "minutes",
+            true
           )
         }
 


### PR DESCRIPTION
Booking button would be disabled one minute before it should because when the time diff is less than a minute it will return 0.

Added the third parameter to make it return an untruncated float instead.