### PR TITLE
Use new icon for normal selected pin

### DIFF
--- a/beeline/services/MapOptions.js
+++ b/beeline/services/MapOptions.js
@@ -46,6 +46,14 @@ angular.module("beeline").service("MapOptions", [
             },
             zIndex: google.maps.Marker.MAX_ZINDEX + 2,
           },
+          normalPinMarker: {
+            icon: {
+              url: "img/map/SelectedPinNormal@2x.png",
+              scaledSize: new googleMaps.Size(34, 46),
+              anchor: new googleMaps.Point(17, 41),
+            },
+            zIndex: google.maps.Marker.MAX_ZINDEX + 2,
+          },
         },
         pathOptions: {
           routePath: {

--- a/static/templates/map-view.html
+++ b/static/templates/map-view.html
@@ -27,7 +27,7 @@
 <ui-gmap-marker ng-if="mapObject.chosenStop"
                 idkey="'selectedStopPin'"
                 coords="mapObject.chosenStop.coordinates"
-                options="mapObject.chosenStop.canBoard ? map.markerOptions.startMarker : map.markerOptions.endMarker">
+                options="mapObject.chosenStop.canBoard ? (mapObject.chosenStop.canAlight ? map.markerOptions.normalPinMarker : map.markerOptions.startMarker) : map.markerOptions.endMarker">
 </ui-gmap-marker>
 <map-bus-icon ng-repeat="recentPings in mapObject.allRecentPings track by $index"
               idkey="'bus-icon' + $index"


### PR DESCRIPTION
- Add new pin marker
- Add logic to display normal pin marker when stop both `canAlight` and `canBoard` (i.e. lite route loop stops)