### PR TITLE
Reset feedback all the time in booking summary

### DIFF
--- a/beeline/controllers/BookingSummaryController.js
+++ b/beeline/controllers/BookingSummaryController.js
@@ -191,9 +191,7 @@ export default [
     })
 
     $scope.$watch("book.promoCodeEntered", () => {
-      if ($scope.book.promoCodeEntered && $scope.book.promoCodeEntered != "") {
-        $scope.book.feedback = ""
-      }
+      $scope.book.feedback = ""
     })
 
     $scope.$watch("book.promoCode", () => {


### PR DESCRIPTION
Reset the feedback even if `promoCodeEntered` is the empty string.