### PR TITLE
Set bidded to false when user is not logged in

### DIFF
--- a/beeline/controllers/KickstarterDetailController.js
+++ b/beeline/controllers/KickstarterDetailController.js
@@ -24,7 +24,11 @@ export default [
     // ------------------------------------------------------------------------
     const updateBidded = async function updateBidded([user, routePromise]) {
       const route = await routePromise
-      if (!user || !route) return
+      if (!route) return
+
+      if (!user) {
+        $scope.disp.bidded = false
+      }
 
       // Figure out if user has bidded on this crowdstart route
       let userIds = route.bids.map(bid => bid.userId)


### PR DESCRIPTION
Set `disp.bidded` to false when user is not logged in.

This results in the join crowdstart button appearing even if the user is not logged in.

The log in prompt will only appear in the crowdstart summary page, similar to how we're doing it for regular routes and booking summary.