### PR TITLE
Remove cancel button for user registration

### DIFF
--- a/beeline/services/UserService.js
+++ b/beeline/services/UserService.js
@@ -172,7 +172,6 @@ angular.module("beeline").factory("UserService", [
         subTitle: "",
         scope: promptScope,
         buttons: [
-          { text: "Cancel" },
           {
             text: "OK",
             type: "button-positive",


### PR DESCRIPTION
Remove cancel button for user registration because we want to nudge users to give us their name and email address