### PR TITLE
Add route pass details to private routes

### DIFF
--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -175,7 +175,7 @@ export default [
       [
         () => RoutesService.getRecentRoutes(),
         () => RoutesService.getRoutesWithRoutePass(),
-        () => RoutesService.getPrivateRoutes(),
+        () => RoutesService.getPrivateRoutesWithRoutePass(),
       ],
       ([recentRoutes, allRoutes, privateRoutes]) => {
         // If we cant find route data here then proceed with empty

--- a/beeline/directives/routesList/routesList.html
+++ b/beeline/directives/routesList/routesList.html
@@ -7,7 +7,7 @@
   </div>
   <!-- hide route item if search bar is not empty -->
   <ion-item
-    ng-repeat="route in data.routesYouMayLike | limitTo:5 track by route.id"
+    ng-repeat="route in data.routesYouMayLike | limitTo:10 track by route.id"
     ng-if="data.routesYouMayLike.length > 0 && !data.placeQuery"
     ui-sref="tabs.route-detail({
       routeId: route.id
@@ -26,7 +26,7 @@
     Available Routes
   </div>
   <ion-item
-    ng-repeat="route in data.routes | limitTo:30 track by route.id"
+    ng-repeat="route in data.routes | limitTo:20 track by route.id"
     ui-sref="tabs.route-detail({ routeId: route.id })"
     class="item-text-wrap"
   >


### PR DESCRIPTION
- Add route pass details to private routes
- Unfortunately requires non-trivial changes in RoutesService
- `fetchPrivateRoutesWithRoutePass` is basically `fetchRoutesWithRoutePass` but because they modify different globals inside the function, I couldn't think of a better way to do this without duplicating the code
- Change the lengths of the route sub-lists in `routesList`