### PR TITLE
Use new data model for trip statuses

### DIFF
--- a/beeline/directives/ticketDetailModal/ticketDetailModal.js
+++ b/beeline/directives/ticketDetailModal/ticketDetailModal.js
@@ -41,7 +41,7 @@ angular.module("beeline").directive("ticketDetailModal", [
           TripService.getTripData(Number(id), true).then(trip => {
             scope.vehicleId = trip.vehicleId
             scope.disp = {
-              vehicle: trip && trip.vehicle && trip.vehicle.vehicleNumber,
+              vehicle: _.get(trip, "vehicle.vehicleNumber"),
             }
           })
         }

--- a/beeline/directives/ticketDetailModal/ticketDetailModal.js
+++ b/beeline/directives/ticketDetailModal/ticketDetailModal.js
@@ -45,8 +45,6 @@ angular.module("beeline").directive("ticketDetailModal", [
                 info.trip &&
                 info.trip.vehicle &&
                 info.trip.vehicle.vehicleNumber,
-              driver:
-                info && info.trip && info.trip.driver && info.trip.driver.name,
             }
             scope.latestInfo = {
               vehicleId:
@@ -76,7 +74,7 @@ angular.module("beeline").directive("ticketDetailModal", [
         }
 
         const updateStatus = status => {
-          scope.disp.tripStatus = status.status
+          scope.disp.tripStatus = status
         }
 
         const deregister = function() {

--- a/beeline/services/MapViewFactory.js
+++ b/beeline/services/MapViewFactory.js
@@ -122,11 +122,13 @@ angular.module("beeline").factory("MapViewFactory", [
 
           await Promise.all(
             scope.mapObject.pingTrips.map((trip, index) => {
-              return TripService.statuses(trip.id).then(statuses => {
-                const status = _.get(statuses, "[0]", null)
+              return TripService.getTripData(trip.id).then(trip => {
+                if (!trip) return
+
+                const status = trip.status
                 scope.mapObject.statusMessages[index] = _.get(
-                  status,
-                  "message",
+                  trip.messages,
+                  "[0].message",
                   null
                 )
 

--- a/beeline/services/data/TripService.js
+++ b/beeline/services/data/TripService.js
@@ -36,15 +36,6 @@ angular.module("beeline").factory("TripService", [
           timeout: 10000,
         }).then(response => response.data)
       },
-
-      statuses: function(id) {
-        assert(typeof id === "number")
-        return RequestService.beeline({
-          method: "GET",
-          url: `/trips/${id}/statuses?limit=5`,
-          timeout: 10000,
-        }).then(response => response.data)
-      },
     }
   },
 ])

--- a/beeline/services/data/TripService.js
+++ b/beeline/services/data/TripService.js
@@ -4,11 +4,14 @@ angular.module("beeline").factory("TripService", [
   "RequestService",
   function TripService(RequestService) {
     return {
-      getTripData: function(id) {
+      getTripData: function(id, includeVehicle) {
         assert(typeof id === "number")
         return RequestService.beeline({
           method: "GET",
           url: "/trips/" + id,
+          params: {
+            includeVehicle,
+          },
         }).then(function(response) {
           return response.data
         })
@@ -26,15 +29,6 @@ angular.module("beeline").factory("TripService", [
           }
           return response.data
         })
-      },
-
-      latestInfo: function(id) {
-        assert(typeof id === "number")
-        return RequestService.beeline({
-          method: "GET",
-          url: `/trips/${id}/latest_info`,
-          timeout: 10000,
-        }).then(response => response.data)
       },
     }
   },


### PR DESCRIPTION
- Use new data model for trip statuses where the status and status messages are in the trip object
- Change use of `TripService.statuses` and `TripService.latestInfo` to `TripService.getTripData`, so we should no longer be using `/trips/{id}/latest_info` and `/trips/{id}/statuses`

Only merge when backend changes for the new data model are done and necessary data backfill is completed.

Fixes #631 