### PR TITLE
Move ui-sref from ion-item to *-route

### DIFF
--- a/beeline/directives/routesList/routesList.html
+++ b/beeline/directives/routesList/routesList.html
@@ -11,15 +11,21 @@
     ng-if="data.routesYouMayLike.length > 0 && !data.placeQuery"
     class="item-text-wrap"
   >
-    <regular-route route="route" ng-if="!route.tags.includes('crowdstart') && !route.tags.includes('lite')" ui-sref="tabs.route-detail({
-      routeId: route.id
-    })"></regular-route>
-    <crowdstart-route route="route" ng-if="route.tags.includes('crowdstart')" ui-sref="tabs.crowdstart-detail({
-      routeId: route.id
-    })"></crowdstart-route>
-    <lite-route route="route" ng-if="route.tags.includes('lite')" ui-sref="tabs.lite-detail({
-      label: route.label
-    })"></lite-route>
+    <regular-route
+      route="route"
+      ng-if="!route.tags.includes('crowdstart') && !route.tags.includes('lite')" 
+      ui-sref="tabs.route-detail({ routeId: route.id})">    
+    </regular-route>
+    <crowdstart-route
+      route="route"
+      ng-if="route.tags.includes('crowdstart')"
+      ui-sref="tabs.crowdstart-detail({ routeId: route.id })">
+    </crowdstart-route>
+    <lite-route
+      route="route"
+      ng-if="route.tags.includes('lite')"
+      ui-sref="tabs.lite-detail({ label: route.label })">
+    </lite-route>
   </ion-item>
   <!-- END: Routes you may like -->
 
@@ -32,10 +38,12 @@
   </div>
   <ion-item
     ng-repeat="route in data.routes | limitTo:20 track by route.id"
-    ui-sref="tabs.route-detail({ routeId: route.id })"
     class="item-text-wrap"
   >
-    <regular-route route="route"></regular-route>
+    <regular-route
+      route="route"
+      ui-sref="tabs.route-detail({ routeId: route.id })">
+    </regular-route>
   </ion-item>
   <!-- END: Available Routes Section -->
   
@@ -50,9 +58,11 @@
   <ion-item
     ng-repeat="route in data.crowdstartRoutes | limitTo:30 track by $index"
     class="item-text-wrap"
-    ui-sref="tabs.crowdstart-detail({ routeId: route.id})"
   >
-    <crowdstart-route route="route"></crowdstart-route>
+    <crowdstart-route
+      route="route"
+      ui-sref="tabs.crowdstart-detail({ routeId: route.id})">
+    </crowdstart-route>
   </ion-item>
   <!-- END: Available Crowdstart Section -->
 
@@ -65,9 +75,12 @@
   </div>
   <ion-item
     ng-repeat="route in data.liteRoutes | limitTo:10 track by route.label"
-    ui-sref="tabs.lite-detail({ label: route.label })"
+    class="item-text-wrap"
   >
-    <lite-route route="route"></lite-route>
+    <lite-route
+      route="route"
+      ui-sref="tabs.lite-detail({ label: route.label })">
+    </lite-route>
   </ion-item>
   <!-- END: Available Lite Routes Section -->
   

--- a/beeline/directives/routesList/yourRoutesList.html
+++ b/beeline/directives/routesList/yourRoutesList.html
@@ -17,25 +17,29 @@
   </div>
   <ion-item
     ng-repeat="route in data.routesWithRidesRemaining | limitTo:10 track by route.id"
-    ui-sref="tabs.route-detail({
-      routeId: route.id
-    })"
     class="item-text-wrap"
     ng-if="data.routesWithRidesRemaining.length > 0"
   >
-    <regular-route route="route"></regular-route>
+    <regular-route
+      route="route"
+      ui-sref="tabs.route-detail({
+        routeId: route.id
+      })">
+    </regular-route>
   </ion-item>
   <ion-item
     ng-repeat="route in data.recentRoutes | limitTo:10 track by route.id"
     ng-if="data.recentRoutes.length > 0"
-    ui-sref="tabs.route-detail({
-      routeId: route.id,
-      pickupStopId:  route.boardStopStopId,
-      dropoffStopId: route.alightStopStopId,
-    })"
     class="item-text-wrap"
   >
-    <regular-route route="route"></regular-route>
+    <regular-route
+      route="route"
+      ui-sref="tabs.route-detail({
+        routeId: route.id,
+        pickupStopId:  route.boardStopStopId,
+        dropoffStopId: route.alightStopStopId,
+      })">
+    </regular-route>
   </ion-item>
   <!-- END: Recently Booked Routes Section -->
 
@@ -49,9 +53,11 @@
   <ion-item
     ng-repeat="route in data.backedCrowdstartRoutes | limitTo:10 track by route.id"
     ng-if="data.backedCrowdstartRoutes.length > 0"
-    class="item-text-wrap"
-    ui-sref="tabs.crowdstart-detail({ routeId: route.id })">
-    <crowdstart-route route="route"></crowdstart-route>
+    class="item-text-wrap">
+    <crowdstart-route
+      route="route"
+      ui-sref="tabs.crowdstart-detail({ routeId: route.id })">
+    </crowdstart-route>
   </ion-item>
   <!-- END: Crowdstart Routes Section -->
 
@@ -62,12 +68,13 @@
   <ion-item
     ng-repeat="route in data.subscribedLiteRoutes | limitTo:10 track by route.label"
     ng-if="data.subscribedLiteRoutes.length > 0"
-    ui-sref="tabs.lite-detail({
-      label: route.label
-    })"
     class="item-text-wrap"
   >
-    <lite-route route="route"></lite-route>
+    <lite-route route="route"
+      ui-sref="tabs.lite-detail({
+        label: route.label
+      })">
+    </lite-route>
   </ion-item>
   <!-- END: Bookmarked Tracking Routes Section -->
 

--- a/scss/routes-list.scss
+++ b/scss/routes-list.scss
@@ -14,4 +14,7 @@
     width: 100%;
   }
 
+  route-item {
+    width: 90%;
+  }
 }


### PR DESCRIPTION
Put `ui-sref` on the `<*-route>` tag rather than on the `<ion-item>` tag.

We had to do this to accommodate multiple types of routes in a single `ng-repeat` i.e. for `routesYouMayLike`.

Where we put the `ui-sref` matters because ionic decides to inject an `item-complex` class in one case and not the other. That was making styling inconsistent, so that's why we have to standardize all of this.