### PR TITLE
UI fixes and making default results loading smoother

### DIFF
--- a/beeline/common/OneMapPlaceService.js
+++ b/beeline/common/OneMapPlaceService.js
@@ -17,6 +17,22 @@ angular.module('common').factory('OneMapPlaceService', [
       return result
     }
 
+    const getAllResults = async function getAllResults (queryText) {
+      let result = await makeQuery(queryText)
+      if (!result || (result && result.found === 0)) {
+        return null
+      } else {
+        result.results = result.results.map(location => {
+          for (var prop in location) {
+            // Transform text to lower case. Use CSS to style appropriately
+            location[prop] = location[prop].toLowerCase()
+          }
+          return location
+        })
+        return result
+      }
+    }
+
     return {
       async handleQuery (queryText) {
         let result = await makeQuery(queryText)
@@ -36,20 +52,16 @@ angular.module('common').factory('OneMapPlaceService', [
         }
       },
 
-      async getAllResults (queryText) {
-        let result = await makeQuery(queryText)
-        if (!result || (result && result.found === 0)) {
-          return null
-        } else {
-          result.results = result.results.map(location => {
-            for (var prop in location) {
-              // Transform text to lower case. Use CSS to style appropriately
-              location[prop] = location[prop].toLowerCase()
-            }
-            return location
-          })
-          return result
+      getAllResults,
+
+      async getTopResult (queryText) {
+        let results = await getAllResults(queryText)
+        if (results) {
+          let location = results.results[0]
+          location.ADDRESS = queryText
+          return location
         }
+        return null
       },
     }
   },

--- a/beeline/directives/locationSearch/locationSearch.js
+++ b/beeline/directives/locationSearch/locationSearch.js
@@ -45,8 +45,8 @@ angular.module('beeline').directive('locationSearch', [
           modalScope.queryLocation = scope.queryLocation
           modalScope.type = scope.icon
           modalScope.location = scope.queryLocation
-          modalScope.callback = location => {
-            scope.queryLocation = location
+          modalScope.callback = async location => {
+            scope.queryLocation = await location
           }
           let modal = $ionicModal.fromTemplate(locationSelectModalTemplate, {
             scope: modalScope,

--- a/beeline/directives/locationSearch/locationSearch.js
+++ b/beeline/directives/locationSearch/locationSearch.js
@@ -45,8 +45,8 @@ angular.module('beeline').directive('locationSearch', [
           modalScope.queryLocation = scope.queryLocation
           modalScope.type = scope.icon
           modalScope.location = scope.queryLocation
-          modalScope.callback = async location => {
-            scope.queryLocation = await location
+          modalScope.callback = location => {
+            scope.queryLocation = location
           }
           let modal = $ionicModal.fromTemplate(locationSelectModalTemplate, {
             scope: modalScope,

--- a/beeline/directives/locationSelectModal/locationSelectModal.js
+++ b/beeline/directives/locationSelectModal/locationSelectModal.js
@@ -79,18 +79,11 @@ angular.module('beeline').directive('locationSelectModal', [
 
         scope.defaultResults = defaultResults
 
-        Promise.all(defaultResults.map(result => {
-          return OneMapPlaceService.getAllResults(result).then(results => {
-            if (results) {
-              let location = results.results[0]
-              location.ADDRESS = result
-              return location
-            }
+        Promise.all(defaultResults.map(OneMapPlaceService.getTopResult))
+          .then(results => {
+            scope.isFiltering = false
+            scope.defaultResults = results
           })
-        })).then(results => {
-          scope.isFiltering = false
-          scope.defaultResults = results
-        })
 
         scope.placeholder = scope.type === 'pickup' ? 'Pick Up Address' : 'Drop Off Address'
 
@@ -122,12 +115,16 @@ angular.module('beeline').directive('locationSelectModal', [
           scope.modal.hide()
         }
 
-        scope.select = async location => {
-          if (typeof location === 'string') return
+        scope.select = location => {
+          if (!location) return
 
-          scope.selectedLocation = location
+          if (typeof location === 'string') {
+            location = OneMapPlaceService.getTopResult(location)
+            return
+          }
+
           if (typeof scope.callback === 'function') {
-            scope.callback(scope.selectedLocation)
+            scope.callback(Promise.resolve(location))
           }
           scope.modal.hide()
         }

--- a/beeline/directives/locationSelectModal/locationSelectModal.js
+++ b/beeline/directives/locationSelectModal/locationSelectModal.js
@@ -79,12 +79,6 @@ angular.module('beeline').directive('locationSelectModal', [
 
         scope.defaultResults = defaultResults
 
-        Promise.all(defaultResults.map(OneMapPlaceService.getTopResult))
-          .then(results => {
-            scope.isFiltering = false
-            scope.defaultResults = results
-          })
-
         scope.placeholder = scope.type === 'pickup' ? 'Pick Up Address' : 'Drop Off Address'
 
         // ---------------------------------------------------------------------
@@ -120,11 +114,10 @@ angular.module('beeline').directive('locationSelectModal', [
 
           if (typeof location === 'string') {
             location = OneMapPlaceService.getTopResult(location)
-            return
           }
 
           if (typeof scope.callback === 'function') {
-            scope.callback(Promise.resolve(location))
+            Promise.resolve(location).then(scope.callback)
           }
           scope.modal.hide()
         }

--- a/scss/location-select-modal.scss
+++ b/scss/location-select-modal.scss
@@ -29,6 +29,8 @@ $search-background-color: #e8e8e8;
 
     .location-result {
       text-transform: capitalize;
+      padding-top: $padding-large-vertical;
+      padding-bottom: $padding-large-vertical;
     }
   }
 
@@ -46,6 +48,10 @@ $search-background-color: #e8e8e8;
       margin-top: auto;
       margin-bottom: auto;
     }
+  }
+
+  input {
+    color: $dark;
   }
 
   // Styles for inset modal

--- a/scss/routes-list.scss
+++ b/scss/routes-list.scss
@@ -75,10 +75,10 @@ $search-background-color: #e8e8e8;
       .switch-container {
         position: absolute;
         right: 4px;
-        top: 31px;
+        top: 23px;
         z-index: 100;
         background: white;
-        padding: 0px 10px;
+        padding: 10px 16px;
 
         .switch-button {
           border: none;


### PR DESCRIPTION
Sends back the selected location as a promise for the main page to resolve, fixing the problem where if onemap doesn't respond quickly enough to our initial query for the default location, we just make a new query and pass it off to the main routes list page.