### PR TITLE
revgeocode - query onemap directly

### DIFF
--- a/beeline/common/OneMapPlaceService.js
+++ b/beeline/common/OneMapPlaceService.js
@@ -68,36 +68,50 @@ angular.module('common').factory('OneMapPlaceService', [
       var now = new Date().getTime()
 
       /* 10 minutes to expiry */
-      if (lastToken.exp * 1e3 - now > 10 * 60e3) {
-        return lastToken.token
-      } else {
+      if (lastToken.exp * 1e3 - now < 10 * 60e3) {
         var url = 'https://developers.onemap.sg/publicapi/publicsessionid'
 
-        const token = await $http({ url, method: 'GET' })
+        await $http({ url, method: 'GET' })
           .then(response => {
             lastToken.exp = response.data.expiry_timestamp
             lastToken.token = response.data.access_token
             return response.data.access_token
           })
-
-        return token
+          .catch(err => {
+            console.warn('Unable to obtain token, using last known one', err)
+          })
       }
+
+      return lastToken.token
     }
 
     return {
       async reverseGeocode (lat, lng) {
         let token = await getToken()
-        let url = 'https://developers.onemap.sg/publicapi/revgeocode?'
-        let queryString = querystring.stringify({
-          token,
-          location: lat + ',' + lng,
-        })
-        let { data: result } = await $http({
-          method: 'GET',
-          url: url + queryString,
-        })
 
-        return transfromRevGeocodeResults(result.GeocodeInfo[0])
+        const onemapCoords = {
+          LATITUDE: String(lat),
+          LONGITUDE: String(lng),
+        }
+        let geocodeInfo
+        if (token) {
+          let queryString = querystring.stringify({
+            token,
+            location: lat + ',' + lng,
+          })
+          let url = 'https://developers.onemap.sg/publicapi/revgeocode?' + queryString
+          let { data: result } = await $http({ method: 'GET', url })
+            .catch(err => {
+              console.warn('Unable to query onemap for reverse geocode', err)
+              return { data: { GeocodeInfo: [ onemapCoords ] } }
+            })
+          geocodeInfo = result.GeocodeInfo[0]
+        } else {
+          console.warn('Unable to query onemap - no API token available')
+          geocodeInfo = onemapCoords
+        }
+
+        return transfromRevGeocodeResults(geocodeInfo)
       },
 
       async handleQuery (queryText) {


### PR DESCRIPTION
The latest onemap API allows an API key to be obtained for
sporadic use. Take advantage of this and let the frontend query
onemap directly for reverse geocode lookups, freeing up the backend
to focus on other requests