### PR TITLE
Re-enable in-app suggestions

### DIFF
--- a/beeline/common/RequestService.js
+++ b/beeline/common/RequestService.js
@@ -53,12 +53,33 @@ angular.module('common').factory('RequestService', [
       return $http(options)
     }
 
+    /**
+     * Send a standard http request to the endpoint defined in
+     * `process.env.ROUTING_URL`. Usually used to retrieve recent pings to
+     * determine trip vehicle location and bearing
+     * @param {object} options - the standard options object, with one
+     * exception - the url specified will be relative to `process.env.ROUTING_URL`
+     * @return {object} the $http response
+     */
+    function routing (options) {
+      options.url = process.env.ROUTING_URL + options.url
+      let sessionToken = window.localStorage.sessionToken || null
+      // Attach the session token if logged in
+      if (sessionToken) {
+        options.headers = {
+          authorization: 'Bearer ' + sessionToken,
+        }
+      }
+      return $http(options)
+    }
+
     // ////////////////////////////////////////////////////////////////////////////
     // Public external interface
     // ////////////////////////////////////////////////////////////////////////////
     return {
       beeline: beelineRequest,
       tracking,
+      routing,
     }
   },
 ])

--- a/beeline/controllers/RoutesSearchListController.js
+++ b/beeline/controllers/RoutesSearchListController.js
@@ -81,7 +81,9 @@ export default [
       dropOffLocation: $stateParams.dropOffLocation,
     }
 
-    $scope.disp = {}
+    $scope.disp = {
+      displaySuggestBtn: $stateParams.displaySuggestBtn,
+    }
 
     // ------------------------------------------------------------------------
     // Ionic events

--- a/beeline/controllers/TabsController.js
+++ b/beeline/controllers/TabsController.js
@@ -85,12 +85,15 @@ export default [
     // ------------------------------------------------------------------------
     // Watchers
     // ------------------------------------------------------------------------
-    $scope.$watch(
+    $scope.$watchGroup([
       () => UserService.getUser(),
-      user => {
-        $scope.disp.isLoggedIn = user !== null
-        $scope.disp.hasSuggestions = false
-      }
+      () => SuggestionService.getSuggestions(),
+    ],
+    ([user, suggestions]) => {
+      if (!user || !suggestions) return
+      $scope.disp.hasSuggestions = suggestions && suggestions.length > 0
+      $scope.disp.isLoggedIn = user !== null
+    }
     )
 
     $scope.$watch('mapObject.stops', stops => {
@@ -131,10 +134,6 @@ export default [
       if (stop) {
         panToStop(stop.stop)
       }
-    })
-
-    $scope.$watch(() => SuggestionService.getSuggestions(), suggestions => {
-      $scope.disp.hasSuggestions = suggestions && suggestions.length > 0
     })
 
     // Watcher for side menu opening event

--- a/beeline/controllers/YourSuggestionDetailController.js
+++ b/beeline/controllers/YourSuggestionDetailController.js
@@ -3,29 +3,80 @@ export default [
   '$state',
   '$stateParams',
   '$ionicPopup',
-  '$ionicLoading',
   'loadingSpinner',
-  'UserService',
   'RoutesService',
   'SuggestionService',
   'CrowdstartService',
+  '$ionicLoading',
+  '$timeout',
   function (
     // Angular Tools
     $scope,
     $state,
     $stateParams,
     $ionicPopup,
-    $ionicLoading,
     loadingSpinner,
-    UserService,
     RoutesService,
     SuggestionService,
-    CrowdstartService
+    CrowdstartService,
+    $ionicLoading,
+    $timeout
   ) {
     // ------------------------------------------------------------------------
     // Helper Functions
     // ------------------------------------------------------------------------
+    function initialiseLoadingCounter () {
+      let now = new Date()
+      let createdAt = new Date($scope.data.suggestion.createdAt)
+      let timeSinceCreated = (now - createdAt) / 1000
 
+      let maxWaitingTime = $scope.loadingBar.maxWaitingPercentage / $scope.loadingBar.counterProgress
+
+      let counter
+      // set counter based on time passed since suggestion was created
+      if (timeSinceCreated > maxWaitingTime) {
+        counter = $scope.loadingBar.maxWaitingPercentage
+      } else {
+        counter = timeSinceCreated * $scope.loadingBar.counterProgress
+      }
+
+      // if suggestion is more than 2 mins old, start counter from 0
+      if (timeSinceCreated > 2 * 60) {
+        return 0
+      }
+
+      return counter
+    }
+
+    function parseErrorMsg (msg) {
+      if (msg === 'too_few_suggestions') {
+        return 'We will need at least 15 other similar route suggestions to generate a crowdstart route for you.'
+      }
+      if (msg === 'no_routes_found') {
+        return 'We are unable to generate a crowdstart route for you. Please contact us at feedback@beeline.sg.'
+      }
+      return 'Internal server error. Please try again later.'
+    }
+
+    function startTimer () {
+      $scope.loadingBarTimer = setInterval(function () {
+        // If user is still on the same page and route is stil being generated
+        // after timer has reached 80%, pause the timer
+        if (
+          $scope.loadingBar.counter >= $scope.loadingBar.maxWaitingPercentage &&
+            !$scope.data.suggestedRoute
+        ) {
+          $scope.$apply()
+          return
+        }
+
+        $scope.loadingBar.counter += $scope.loadingBar.counterProgress
+        $scope.$apply()
+        if ($scope.loadingBar.counter > 100) {
+          clearInterval($scope.loadingBarTimer)
+        }
+      }, 1000)
+    }
     // ------------------------------------------------------------------------
     // stateParams
     // ------------------------------------------------------------------------
@@ -36,9 +87,18 @@ export default [
     // ------------------------------------------------------------------------
     $scope.data = {
       suggestionId: suggestionId,
-      suggestion: null,
-      routes: null,
+      suggestion: $stateParams.suggestion,
+      suggestedRoute: $stateParams.suggestedRoute,
+      isLoading: false,
     }
+    $scope.refreshSuggestedRoutesTimer = null
+    $scope.loadingBarTimer = null
+
+    $scope.loadingBar = {
+      maxWaitingPercentage: 80,
+      counterProgress: 5, // Percentage that counter progress per sec
+    }
+    $scope.loadingBar.counter = initialiseLoadingCounter()
 
     // ------------------------------------------------------------------------
     // Ionic events
@@ -46,44 +106,34 @@ export default [
     // Load the route information
     // Show a loading overlay while we wait
     // force reload when revisit the same route
-    $scope.$on('$ionicView.afterEnter', () => {
-      $ionicLoading.show({
-        template: `<ion-spinner icon='crescent'></ion-spinner><br/><small>Loading route information</small>`,
-      })
-
-      SuggestionService.getSuggestion(suggestionId)
-        .then(response => {
-          $scope.data.suggestion = response.details
-        })
-        .catch(error => {
-          $ionicLoading.hide()
-          $ionicPopup.alert({
-            title: "Sorry there's been a problem loading the suggested route information",
-            subTitle: error,
-          })
-        })
-
-      $scope.refreshSuggestedRoutes(suggestionId)
+    $scope.$on('$ionicView.beforeEnter', () => {
+      if (!$scope.data.suggestedRoute) {
+        $scope.data.isLoading = true
+        startTimer()
+        $scope.refreshSuggestedRoutes(suggestionId)
+      }
     })
 
     $scope.$on('$ionicView.leave', () => {
-      $scope.data.suggestionId = null
-      $scope.data.suggestion = null
-      $scope.data.routes = null
+      clearInterval($scope.refreshSuggestedRoutesTimer)
+      clearInterval($scope.loadingBarTimer)
+      $scope.data.suggestedRoute = null
     })
 
     // ------------------------------------------------------------------------
     // Watchers
     // ------------------------------------------------------------------------
-    $scope.$watchGroup(
-      ['data.suggestion', 'data.routes'],
-      ([suggestion, routes]) => {
-        if (suggestion && routes) {
-          $ionicLoading.hide()
-        }
+    $scope.$watch('data.suggestedRoute', route => {
+      if (route && route.info.status === 'Failure') {
+        let msg = parseErrorMsg(route.info.reason)
+        $ionicPopup.alert({
+          title: 'We are sorry!',
+          template: `
+          <div>${msg}</div>
+          `,
+        })
       }
-    )
-
+    })
     // ------------------------------------------------------------------------
     // UI Hooks
     // ------------------------------------------------------------------------
@@ -94,7 +144,7 @@ export default [
 
     $scope.popupDeleteConfirmation = function () {
       $ionicPopup.confirm({
-        title: 'Are you sure you want to delete the suggestions?',
+        title: 'Are you sure you want to delete this suggestion?',
       }).then(async (proceed) => {
         if (proceed) {
           try {
@@ -121,21 +171,52 @@ export default [
     }
 
     $scope.refreshSuggestedRoutes = function (suggestionId) {
-      SuggestionService.fetchSuggestedRoutes(suggestionId)
+      SuggestionService.fetchSuggestedRoute(suggestionId)
         .then(data => {
-          if (!data.done) {
-            setTimeout(() => $scope.refreshSuggestedRoutes(suggestionId), 5000)
+          if (!data) {
+            $scope.refreshSuggestedRoutesTimer = setTimeout(() => $scope.refreshSuggestedRoutes(suggestionId), 5000)
           } else {
-            $scope.data.routes = data.routes
+            let delay = 0
+
+            // if result is returned too fast
+            // simulate a 2 sec loading time for user
+            if ($scope.loadingBar.counter < 2 * $scope.loadingBar.counterProgress) {
+              delay = 2000
+            }
+
+            $timeout(() => {
+              $scope.data.suggestedRoute = data
+              $scope.data.isLoading = false
+              clearInterval($scope.refreshSuggestedRoutesTimer)
+              clearInterval($scope.loadingBarTimer)
+              $scope.loadingBar.counter = 0
+            }, delay)
           }
         })
         .catch(error => {
-          $ionicLoading.hide()
           $ionicPopup.alert({
             title: "Sorry there's been a problem loading the suggested route information",
             subTitle: error,
           })
         })
+    }
+
+    $scope.showSimilarRoutes = function () {
+      let pickUp = $scope.data.suggestion.boardDescription.oneMapData
+      let dropOff = $scope.data.suggestion.alightDescription.oneMapData
+
+      $ionicLoading.show({
+        template: `<ion-spinner icon='crescent'></ion-spinner><br/><small>Searching for routes</small>`,
+      })
+
+      $timeout(() => {
+        $ionicLoading.hide()
+        $state.go('tabs.routes-search-list', {
+          pickUpLocation: pickUp,
+          dropOffLocation: dropOff,
+          displaySuggestBtn: false,
+        })
+      }, 800)
     }
   },
 ]

--- a/beeline/controllers/YourSuggestionsController.js
+++ b/beeline/controllers/YourSuggestionsController.js
@@ -1,10 +1,14 @@
 export default [
   '$scope',
+  '$state',
   'SuggestionService',
+  '$ionicLoading',
   function (
     // Angular Tools
     $scope,
-    SuggestionService
+    $state,
+    SuggestionService,
+    $ionicLoading
   ) {
     // ------------------------------------------------------------------------
     // Helper Functions
@@ -30,5 +34,19 @@ export default [
     // ------------------------------------------------------------------------
     // UI Hooks
     // ------------------------------------------------------------------------
+    $scope.viewSuggestionDetail = async function (suggestion) {
+      $ionicLoading.show({
+        template: `<ion-spinner icon='crescent'></ion-spinner><br/><small>Loading suggestion</small>`,
+      })
+
+      let suggestedRoute = await SuggestionService.fetchSuggestedRoute(suggestion.id)
+
+      $ionicLoading.hide()
+      $state.go('tabs.your-suggestion-detail', {
+        suggestion,
+        suggestedRoute,
+        suggestionId: suggestion.id,
+      })
+    }
   },
 ]

--- a/beeline/directives/progressBar/progressBar.html
+++ b/beeline/directives/progressBar/progressBar.html
@@ -1,6 +1,6 @@
 <div class="progress-bar">
 
-  <div class="backer-numbers mini-info">
+  <div ng-if="displayLabel" class="backer-numbers mini-info">
     <i class="fas fa-user"></i>
     <span>{{backer1}} out of {{pax1}} pax joined</span>
   </div>
@@ -17,7 +17,7 @@
   <!-- default base bar starts -->
   <div class="bar-default" ng-style="{width: (pax1/pax1)*100 + '%'}">
     <div class="bar-100">
-      <div class="milestone">
+      <div ng-if="needed" class="milestone">
         <div class="milestone-outline"  ng-class="{reached: needed==0}">
         </div>
       </div>

--- a/beeline/directives/progressBar/progressBar.js
+++ b/beeline/directives/progressBar/progressBar.js
@@ -11,7 +11,16 @@ angular.module('beeline').directive('progressBar', [
         price1: '<',
         detail: '<',
         needed: '<',
+        displayLabel: '=?',
       },
+      controller: [
+        '$scope',
+        function ($scope) {
+          if (angular.isUndefined($scope.displayLabel)) {
+            $scope.displayLabel = true
+          }
+        },
+      ],
       link: function (scope, elem, attr) {
         scope.$watchGroup(['backer1', 'pax1'], () => {
           scope.percentage = Math.min(scope.backer1 / scope.pax1, 1)

--- a/beeline/directives/routeItem/crowdstartRoute.html
+++ b/beeline/directives/routeItem/crowdstartRoute.html
@@ -19,7 +19,7 @@
   </route-item-end-location>
   <route-item-additional-info>
 
-    <progress-bar backer1="route.notes.tier[0].count " price1="route.notes.tier[0].price"
+    <progress-bar backer1="route.notes.tier[0].count || 0" price1="route.notes.tier[0].price"
       pax1="route.notes.tier[0].pax" needed="route.notes.tier[0].moreNeeded"
       ng-if="!route.isConverted">
     </progress-bar>

--- a/beeline/directives/routesList/routesList.html
+++ b/beeline/directives/routesList/routesList.html
@@ -27,16 +27,22 @@
   </ion-item>
   <!-- END: All routes -->
 
-  <div ng-hide="suggestHide" class="item text-center item-text-wrap suggest-route">
+  <div 
+    ng-if="disp.routes.length === 0 &&
+    disp.liteRoutes.length === 0 &&
+    disp.crowdstartRoutes.length === 0" 
+    ng-hide="suggestHide" 
+    class="item text-center item-text-wrap suggest-route"
+  >
     <!-- No results found message -->
-    <div
-      ng-if="disp.routes.length === 0 &&
-            disp.liteRoutes.length === 0 &&
-            disp.crowdstartRoutes.length === 0"
-      class=""
-    >
-      Sorry, we could not find any routes matching your search query.
-    </div>
+    Sorry, we could not find any routes matching your search query.
+  </div>
+
+  <div 
+    ng-if="disp.displaySuggestBtn" 
+    ng-hide="suggestHide" 
+    class="item text-center item-text-wrap suggest-route"
+  >
     <div
       ng-if="disp.routes.length !== 0 ||
             disp.liteRoutes.length !== 0 ||
@@ -45,9 +51,15 @@
       Can't find a suitable route?
     </div>
 
+    <!-- To open web suggestion page --> 
+    <!-- ng-click="openLink($event)" --> 
     <button
+      ng-if="disp.displaySuggestBtn"
       class="primary-button" 
-      ng-click="openLink($event)"
+      ui-sref="tabs.create-new-suggestion({
+        pickUpLocation: data.pickUpLocation,	
+        dropOffLocation: data.dropOffLocation,	
+      })"
     >
       Suggest a new route
     </button>

--- a/beeline/directives/suggestionItem/suggestionItem.html
+++ b/beeline/directives/suggestionItem/suggestionItem.html
@@ -1,12 +1,5 @@
-<div class="day-badge">
-  <div ng-repeat="(day, enabled) in suggestion.daysOfWeek" ng-class="{'enabled': enabled}">
-    {{ day[0] }}
-  </div>
-</div>
-
-<div class="suggestion-info">
-  <div class="left">
-    <div class="stops">
+<div class="suggestion-detail">
+  <div class="stops">
       <div class="start">
         <span class="stop-icon"></span>
         <span class="road">{{ suggestion.boardDescription.description }}</span>
@@ -16,20 +9,31 @@
         <span class="road">{{ suggestion.alightDescription.description }}</span>
       </div>
     </div>
-    <div class="additional-info">
-      <div class="icon-and-schedule">
-        <span class="icon-span">
-          <i class="far fa-clock fa-fw" aria-hidden="true"></i>
-        </span>
-        <span class="mini-info">
-          Arrive by {{ parseTime(suggestion.time) }}
-        </span>
+  <div class="suggestion-detail-info">
+    <div class="left">
+      <div class="additional-info">
+        <div class="icon-and-schedule">
+          <span class="icon-span">
+            <i class="far fa-clock fa-fw" aria-hidden="true"></i>
+          </span>
+          <span class="mini-info">
+            Arrive by {{ parseTime(suggestion.time) }}
+          </span>
+        </div>
+        <div class="icon-and-schedule">
+          <span class="icon-span">
+            <img class="mini-icon" src="img/icon_schedule.svg">
+          </span>
+          <span class="mini-info">
+            {{ parseSchedule(suggestion.daysOfWeek) }}
+          </span>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="right">
-    <span class="value">{{ suggestion.similar }}</span>
-    <span class="suggestions">Similar</span>
-    <span class="suggestions">Suggestions</span>
+    <div class="right">
+      <span class="value">{{ suggestion.similar }}</span>
+      <span class="suggestions">Similar</span>
+      <span class="suggestions">Suggestions</span>
+    </div>
   </div>
 </div>

--- a/beeline/directives/suggestionItem/suggestionItem.js
+++ b/beeline/directives/suggestionItem/suggestionItem.js
@@ -1,5 +1,6 @@
 import suggestionItemTemplate from './suggestionItem.html'
 import moment from 'moment'
+import _ from 'lodash'
 
 angular.module('beeline').directive('suggestionItem', [
   function () {
@@ -19,6 +20,33 @@ angular.module('beeline').directive('suggestionItem', [
           let minutes = moment.duration(time).minutes()
           minutes = minutes < 10 ? '0' + minutes : minutes
           return hours + '.' + minutes + ' ' + suffix
+        }
+
+        $scope.parseSchedule = function (daysOfWeek) {
+          if (!daysOfWeek) return
+          let week = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+          let weekday = {
+            Mon: true,
+            Tue: true,
+            Wed: true,
+            Thu: true,
+            Fri: true,
+            Sat: false,
+            Sun: false,
+          }
+          let weekend = {
+            Mon: false,
+            Tue: false,
+            Wed: false,
+            Thu: false,
+            Fri: false,
+            Sat: true,
+            Sun: true,
+          }
+
+          if (_.isEqual(daysOfWeek, weekday)) return 'Mon to Fri (Exclude P.H.)'
+          else if (_.isEqual(daysOfWeek, weekend)) return 'Sat, Sun (Exclude P.H.)'
+          else return _.filter(week, d => daysOfWeek[d]).join(', ')
         }
       },
     }

--- a/beeline/router.js
+++ b/beeline/router.js
@@ -60,6 +60,7 @@ export default [
         params: {
           pickUpLocation: null,
           dropOffLocation: null,
+          displaySuggestBtn: true,
         },
       })
       .state('tabs.yourRoutes', {
@@ -213,6 +214,11 @@ export default [
             templateUrl: 'templates/your-suggestion-detail.html',
             controller: 'YourSuggestionDetailController',
           },
+        },
+        params: {
+          suggestionId: null,
+          suggestion: null,
+          suggestedRoute: null,
         },
       })
 

--- a/beeline/services/UserService.js
+++ b/beeline/services/UserService.js
@@ -238,8 +238,12 @@ angular.module('beeline').factory('UserService', [
         // Ask for verification code
         let verificationCode = await promptVerificationCode(telephoneNumber)
         if (!verificationCode) return
-        let user = await loadingSpinner(
+        let user
+        await loadingSpinner(
           verifyTelephone(telephoneNumber, verificationCode.code)
+            .then(u => {
+              user = u
+            })
         )
 
         // Is the user name null?

--- a/beeline/services/data/CrowdstartService.js
+++ b/beeline/services/data/CrowdstartService.js
@@ -241,6 +241,7 @@ angular.module('beeline').service('CrowdstartService', [
 
       getCrowdstartById: function (routeId) {
         if (routeId === 'preview') {
+          transformCrowdstartData([crowdstartPreview])
           return crowdstartPreview
         }
         if (!crowdstartRoutesById) {

--- a/beeline/services/data/SuggestionService.js
+++ b/beeline/services/data/SuggestionService.js
@@ -6,8 +6,8 @@ angular.module('beeline').factory('SuggestionService', [
   'CrowdstartService',
   function SuggestionService (RequestService, UserService, CrowdstartService) {
     let suggestions
-    let routes
     let createdSuggestion
+    let suggestedRoutes = {}
 
     function convertDaysToBinary (days) {
       const week = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
@@ -36,7 +36,7 @@ angular.module('beeline').factory('SuggestionService', [
           lat: sug.alight.coordinates[1],
           lng: sug.alight.coordinates[0],
         }
-        const similar = await fetchSimilarSuggestions(start, end, sug.time)
+        const similar = await fetchSimilarSuggestions(start, end, sug.time, sug.daysOfWeek)
         userSuggestions[index] = {
           ...sug,
           similar,
@@ -59,13 +59,19 @@ angular.module('beeline').factory('SuggestionService', [
       })
     }
 
-    function fetchSimilarSuggestions (start, end, time) {
+    function fetchSimilarSuggestions (start, end, time, daysOfWeek) {
       let queryString = querystring.stringify({
         startLat: start.lat,
         startLng: start.lng,
         endLat: end.lat,
         endLng: end.lng,
         time,
+        startDistance: 350,
+        endDistance: 350,
+        maxTimeDifference: 1800e3, // half an hour
+        includeAnonymous: false,
+        daysMask: convertDaysToBinary(daysOfWeek),
+        createdSince: Date.now() - 2 * 365 * 24 * 60 * 60 * 1000, // 2 years back
       })
       return RequestService.beeline({
         method: 'GET',
@@ -81,14 +87,15 @@ angular.module('beeline').factory('SuggestionService', [
       alight,
       alightDescription,
       time,
-      daysOfWeek
+      daysOfWeek,
+      referrer
     ) {
       return RequestService.beeline({
         method: 'POST',
         url: '/suggestions',
-        data: { board, boardDescription, alight, alightDescription, time, daysOfWeek },
+        data: { board, boardDescription, alight, alightDescription, time, daysOfWeek, referrer },
       }).then(response => {
-        triggerRouteGeneration(response.data.id, response.data.daysOfWeek)
+        triggerRouteGeneration(response.data.id)
         return response.data
       })
     }
@@ -102,35 +109,61 @@ angular.module('beeline').factory('SuggestionService', [
       })
     }
 
-    function triggerRouteGeneration (suggestionId, days) {
-      const daysOfWeek = convertDaysToBinary(days)
+    function triggerRouteGeneration (suggestionId) {
       return RequestService.routing({
         method: 'POST',
         url: `/suggestions/${suggestionId}/trigger_route_generation`,
         data: {
-          maxDetourMinutes: 15,
-          startClusterRadius: 4000,
+          maxDetourMinutes: 0.5,
+          startClusterRadius: 3000,
           startWalkingDistance: 400,
-          endClusterRadius: 4000,
+          endClusterRadius: 3000,
           endWalkingDistance: 400,
           timeAllowance: 1800 * 1000, // Half an hour
-          daysOfWeek, // 0b0011111 - Mon-Fri
-          dataSource: 'suggestions',
+          matchDaysOfWeek: true,
+          imputedDwellTime: 10000,
+          includeAnonymous: false,
+          createdSince: Date.now() - 2 * 365 * 24 * 60 * 60 * 1000, // 2 years back,
+          suboptimalStopChoiceAllowance: 10000,
         },
       }).then(response => {
         return response.data
       })
     }
 
+    async function triggerRouteGenAgain (suggestedRoute) {
+      let now = new Date()
+      let createdAt = new Date(suggestedRoute.createdAt)
+
+      if (
+        // If suggestion is more than one month old
+        // trigger route generation again to refresh the suggested route
+        (suggestedRoute.route.status === 'Success' && now - createdAt > 30 * 24 * 3600e3) ||
+        suggestedRoute.route.status === 'Failure'
+      ) {
+        let suggestionId = suggestedRoute.seedSuggestionId
+        await triggerRouteGeneration(suggestionId)
+
+        if (!suggestedRoutes[suggestionId]) {
+          suggestedRoutes[suggestionId] = {}
+        }
+
+        suggestedRoutes[suggestionId].reTriggerRouteGeneration = true
+        suggestedRoutes[suggestionId].suggRouteLastCreated = new Date(suggestedRoute.createdAt)
+      }
+    }
+
     return {
       createSuggestion: async function (board, boardDescription, alight, alightDescription, time, daysOfWeek) {
+        let referrer = 'Beeline'
         let suggestion = await requestCreateNewSuggestion(
           board,
           boardDescription,
           alight,
           alightDescription,
           time,
-          daysOfWeek
+          daysOfWeek,
+          referrer
         )
         const start = {
           lat: suggestion.board.coordinates[1],
@@ -140,7 +173,7 @@ angular.module('beeline').factory('SuggestionService', [
           lat: suggestion.alight.coordinates[1],
           lng: suggestion.alight.coordinates[0],
         }
-        const similar = await fetchSimilarSuggestions(start, end, suggestion.time)
+        const similar = await fetchSimilarSuggestions(start, end, suggestion.time, suggestion.daysOfWeek)
         createdSuggestion = {
           ...suggestion,
           similar,
@@ -153,9 +186,7 @@ angular.module('beeline').factory('SuggestionService', [
       getSuggestion: function (suggestionId) {
         let details = createdSuggestion || suggestions.filter(sug => sug.id === suggestionId)[0]
         createdSuggestion = null
-        return Promise.resolve({
-          details,
-        })
+        return details
       },
 
       getSuggestions: function () {
@@ -173,36 +204,55 @@ angular.module('beeline').factory('SuggestionService', [
         })
       },
 
-      fetchSuggestedRoutes: function (suggestionId) {
+      fetchSuggestedRoute: function (suggestionId) {
         return RequestService.beeline({
           method: 'GET',
           url: `/suggestions/${suggestionId}/suggested_routes`,
         }).then(async response => {
-          routes = []
-
-          const promises = response.data
-            .filter(r => r.route) // omit any false routes
-            .map(async r => {
-              let route
-              if (r.routeId) {
-                route = await CrowdstartService.getCrowdstartById(r.routeId)
-              } else {
-                route = await previewRoute(suggestionId, r.id)
-              }
-              routes.push({
-                ...route,
-                suggestedRouteId: r.id,
-                suggestionId,
-              })
-            })
-          await Promise.all(promises)
-
-          return {
-            done: response.data.length > 0,
-            routes,
+          if (response.data.length === 0) {
+            return null
           }
+          // Get latest suggested route
+          const r = response.data[0]
+
+          // check if needed to re-trigger route generation
+          if (!suggestedRoutes[suggestionId] || !suggestedRoutes[suggestionId].reTriggerRouteGeneration) {
+            await triggerRouteGenAgain(r)
+          }
+
+          // if route generation has been re-triggered and
+          // a new suggested route has not returned
+          if (suggestedRoutes[suggestionId] && suggestedRoutes[suggestionId].reTriggerRouteGeneration && new Date(r.createdAt) <= suggestedRoutes[suggestionId].suggRouteLastCreated) {
+            return null
+          }
+
+          let route
+          if (r.routeId) {
+            route = await CrowdstartService.getCrowdstartById(r.routeId)
+          }
+          if (r.route.status === 'Success' && !r.routeId) {
+            route = await previewRoute(suggestionId, r.id)
+          }
+
+          let suggestedRoute = {
+            ...route,
+            info: {
+              status: r.route.status,
+              reason: r.route.reason,
+            },
+            suggestedRouteId: r.id,
+            suggestionId,
+            // store the status of route generation
+            reTriggerRouteGeneration: false,
+            suggRouteLastCreated: null,
+          }
+          suggestedRoutes[suggestionId] = suggestedRoute
+
+          return suggestedRoute
         })
       },
+
+      triggerRouteGeneration,
 
       convertToCrowdstart: function (suggestionId, suggestedRouteId) {
         return RequestService.beeline({

--- a/beeline/services/data/SuggestionService.js
+++ b/beeline/services/data/SuggestionService.js
@@ -104,9 +104,9 @@ angular.module('beeline').factory('SuggestionService', [
 
     function triggerRouteGeneration (suggestionId, days) {
       const daysOfWeek = convertDaysToBinary(days)
-      return RequestService.beeline({
+      return RequestService.routing({
         method: 'POST',
-        url: `/suggestions/${suggestionId}/suggested_routes/trigger_route_generation`,
+        url: `/suggestions/${suggestionId}/trigger_route_generation`,
         data: {
           maxDetourMinutes: 15,
           startClusterRadius: 4000,

--- a/beeline/services/data/SuggestionService.js
+++ b/beeline/services/data/SuggestionService.js
@@ -205,7 +205,7 @@ angular.module('beeline').factory('SuggestionService', [
       },
 
       fetchSuggestedRoute: function (suggestionId) {
-        return RequestService.beeline({
+        return RequestService.routing({
           method: 'GET',
           url: `/suggestions/${suggestionId}/suggested_routes`,
         }).then(async response => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -16,6 +16,11 @@ const TRACKING_URL_NOT_SET_MESSAGE = `
 TRACKING_URL environment variable not set. Defaulting to ${DEFAULT_TRACKING_URL}
 `
 
+const DEFAULT_ROUTING_URL = 'https://routing.beeline.sg'
+const ROUTING_URL_NOT_SET_MESSAGE = `
+ROUTING_URL environment variable not set. Defaulting to ${DEFAULT_ROUTING_URL}
+`
+
 const BUILD_COMPLETED_MESSAGE = 'Beeline frontend build process complete'
 const PRODUCTION_BUILD_MESSAGE = `
 Starting production build. Remove the --production flag for development builds
@@ -45,6 +50,7 @@ if (production) {
   console.log(PRODUCTION_BUILD_MESSAGE)
   process.env.BACKEND_URL = DEFAULT_BACKEND_URL
   process.env.TRACKING_URL = DEFAULT_TRACKING_URL
+  process.env.ROUTING_URL = DEFAULT_ROUTING_URL
   shell.exec('webpack -p')
   shell.exec('npm run build-scss')
   shell.exec('cordova-hcp build www/')
@@ -60,6 +66,11 @@ if (production) {
   if (typeof process.env.TRACKING_URL === 'undefined') {
     console.log(TRACKING_URL_NOT_SET_MESSAGE)
     process.env.TRACKING_URL = DEFAULT_TRACKING_URL
+  }
+  // Configure default environment variables for non production builds
+  if (typeof process.env.ROUTING_URL === 'undefined') {
+    console.log(ROUTING_URL_NOT_SET_MESSAGE)
+    process.env.ROUTING_URL = DEFAULT_ROUTING_URL
   }
   if (watch) {
     shell.exec('webpack -w', { async: true })

--- a/scss/your-suggestions.scss
+++ b/scss/your-suggestions.scss
@@ -6,9 +6,6 @@ $search-height: 42px;
 }
 
 suggestion-item {
-  padding: 15px;
-
-  
 
   .day-badge {
     display: flex;
@@ -33,94 +30,89 @@ suggestion-item {
     }
   }
 
-  .suggestion-info {
-    display: flex;
-
-    .right {
-      text-align: right;
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      text-transform: uppercase;
+  .suggestion-detail {
+    .stops {
+      display: block;
+      position: relative;
+      flex: 1 1 auto;
+      margin-right: 60px;
   
-      .value {
-        font-size: 40px;
-        line-height: 40px;
-        font-weight: $font-weight-bold;
-        margin-bottom: 5px;
+      .stop-icon {
+        /* this value depends on the width of the image -- leaving as a constant */
+        flex: 0 0 auto;
+        width: 8px;
+        height: 8px;
+        border-radius: 4px;
+        margin-top: $font-size-base / 2;
+        margin-right: $font-size-base / 2;
       }
-      .suggestions {
-        color: $light-grey;
-        font-size: $font-size-x-small;
+  
+      .start .stop-icon {
+        background: #00C4A5;
+        /*
+          we want line to be:
+              - the height of .start (=> height: 100%),
+              - displace the left of the line to the middle of the circle
+                  the image is 10x10 hence left: 4px (to account for width=2px)
+              - .start is inline, so it's height = $line-height-computed.
+                Image is centered vertically => top = $line-height-computed / 2
+                N.B. overflow must be "visible" on .start for this to work
+              - positioned relative to the stop icon => .start { position: relative }
+        */
+      }
+      .end .stop-icon {
+        background: #FF6C6A;
+      }
+  
+      .start, .end {
+        line-height: $line-height-base;
+        position: relative;
+        white-space: normal;
+        display: flex;
+  
+        .road {
+          text-transform: capitalize;
+          flex: 1 1 auto;
+          white-space: initial;
+          font-weight: $route-item-font-weight-small;
+          color: $normal-grey;
+        }
+      }
+  
+      .end {
+        margin-top: 10px;
+        margin-bottom: 10px;
       }
     }
-  
-    .left {
-      flex: auto;
-      margin-right: 40px;
-  
-      .stops {
-        display: block;
-        /* Determines the amount of vertical spacing
-            between the .bus-number and the stops */
-        margin-top: $font-size-base * 0.8;
-        position: relative;
-        flex: 1 1 auto;
     
-        .stop-icon {
-          /* this value depends on the width of the image -- leaving as a constant */
-          flex: 0 0 auto;
-          width: 8px;
-          height: 8px;
-          border-radius: 4px;
-          margin-top: $font-size-base / 2;
-          margin-right: $font-size-base / 2;
+    .suggestion-detail-info {
+      display: flex;
+
+      .right {
+        text-align: right;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+        text-transform: uppercase;
+    
+        .value {
+          font-size: 34px;
+          line-height: 34px;
+          font-weight: $font-weight-bold;
         }
-    
-        .start .stop-icon {
-          background: #00C4A5;
-          /*
-            we want line to be:
-                - the height of .start (=> height: 100%),
-                - displace the left of the line to the middle of the circle
-                    the image is 10x10 hence left: 4px (to account for width=2px)
-                - .start is inline, so it's height = $line-height-computed.
-                  Image is centered vertically => top = $line-height-computed / 2
-                  N.B. overflow must be "visible" on .start for this to work
-                - positioned relative to the stop icon => .start { position: relative }
-          */
-        }
-        .end .stop-icon {
-          background: #FF6C6A;
-        }
-    
-        .start, .end {
-          line-height: $line-height-base;
-          position: relative;
-          white-space: normal;
-          display: flex;
-    
-          .road {
-            text-transform: capitalize;
-            flex: 1 1 auto;
-            white-space: initial;
-            font-weight: $route-item-font-weight-small;
-            color: $normal-grey;
-          }
-        }
-    
-        .end {
-          margin-top: 10px;
-          margin-bottom: 10px;
+        .suggestions {
+          color: $light-grey;
+          font-size: $font-size-x-small;
+          line-height: 15px;
         }
       }
-  
-      .icon-and-schedule {
-        margin-top: 0.5em;
-        font-weight: $route-item-font-weight-small;
     
-        & + .icon-and-schedule {
+      .left {
+        flex: auto;
+    
+        .icon-and-schedule {
           margin-top: 0em;
+          font-weight: $route-item-font-weight-small;
         }
       }
     }
@@ -129,29 +121,47 @@ suggestion-item {
 
 .your-suggestions {
   .create-suggestion-btn {
-    margin-top: 25px;
-    margin-bottom: 25px;
+    padding: 25px 0;
+
+    button {
+      margin: auto;
+    }
   }
 }
 
 .your-suggestion-detail {
   .header {
     font-size: 20px;
-    line-height: 45px;
+    padding-bottom: 16px;
     font-weight: $font-weight-medium;
     color: $royal;
     text-transform: uppercase;
+    display: block;
   }
   
-  .delete {
-    color: $assertive;
-    margin: 25px 0;
-    text-align: center;
-    text-decoration: underline;
+  .action-link {
+    padding: 25px 0;
+    
+    div {
+      text-align: center;
+      text-decoration: underline;
+      color: $royal;
+    }
+
+    div.delete {
+      padding-top: 16px;
+      color: $assertive;
+    }
   }
 
-  route-item {
-    margin-bottom: 25px;
+  .loading-bar {
+    span {
+      text-align: center;
+    }
+    progress-bar .backer-high {
+      transition: all 1.5s;
+      width: 0%;
+    }
   }
 }
 

--- a/static/templates/create-new-suggestion.html
+++ b/static/templates/create-new-suggestion.html
@@ -20,18 +20,22 @@
         </label>
       </div>
 
-      <div class="stops-selector week-checkbox">
-        <div ng-repeat="day in data.days">
-          <ion-label>{{day.text}}</ion-label>
-          <ion-checkbox ng-model="day.enabled"></ion-checkbox>
-        </div>
+      <div class="stops-selector">
+        <label class="item item-input item-select">
+          <div class="input-label">
+            Days Of The Week
+          </div>
+          <select ng-model="data.selectedScheduleIndex" data-tap-disabled="true">
+            <option ng-repeat="schedule in data.schedule" value={{$index}}>{{ schedule.value }}</option>
+          </select>
+        </label>
       </div>
 
       <button
         ng-if="isLoggedIn"
         class="primary-button submit-btn" 
         ng-click="submitSuggestion()" 
-        ng-disabled="!data.pickUpLocation || !data.dropOffLocation || !data.selectedTimeIndex || data.daysInvalid">
+        ng-disabled="!data.pickUpLocation || !data.dropOffLocation || !data.selectedTimeIndex">
         Submit
       </button>
 

--- a/static/templates/crowdstart-detail.html
+++ b/static/templates/crowdstart-detail.html
@@ -5,13 +5,13 @@
    <menu-hamburger ng-if="disp.showHamburger"></menu-hamburger>
  </ion-nav-buttons>
   <ion-nav-buttons side="right">
-    <route-share route-type="'crowdstart'" route-id="book.routeId"></route-share>
+    <route-share ng-if="book.routeId !== 'preview'" route-type="'crowdstart'" route-id="book.routeId"></route-share>
   </ion-nav-buttons>
 
   <ion-content class="has-header">
 
     <div class="item progress-bar-item">
-      <progress-bar backer1="book.route.notes.tier[0].count"
+      <progress-bar backer1="book.route.notes.tier[0].count || 0"
         price1="book.route.notes.tier[0].price"
         pax1="book.route.notes.tier[0].pax"
         detail=true

--- a/static/templates/tabs.html
+++ b/static/templates/tabs.html
@@ -52,11 +52,11 @@ navigation history that also transitions its views in and out.
         <a class="item divider" menu-close ui-sref="tabs.your-suggestions" ui-sref-active="active" ng-if="disp.isLoggedIn && disp.hasSuggestions">
           <i class="fas fa-comments fa-fw" aria-hidden="true"></i>&nbsp; Your Suggestions
         </a>
-        <a class="item" menu-close ui-sref="tabs.settings" ui-sref-active="active">
-          <i class="fa fa-cog fa-fw" aria-hidden="true"></i>&nbsp; Settings
-        </a>
         <a class="item" menu-close ng-if="!disp.isLoggedIn" ng-click="login()">
           <i class="fa fa-sign-in-alt fa-fw" aria-hidden="true"></i>&nbsp; Log In
+        </a>
+        <a class="item" menu-close ui-sref="tabs.settings" ui-sref-active="active">
+          <i class="fa fa-cog fa-fw" aria-hidden="true"></i>&nbsp; Settings
         </a>
         <powered-by-beeline class="powered-by-beeline" suggest-hide="true" power-hide="false" built-by-show="true"></powered-by-beeline>
       </ion-content>

--- a/static/templates/your-suggestion-detail.html
+++ b/static/templates/your-suggestion-detail.html
@@ -1,4 +1,4 @@
-<ion-view class="your-suggestion-detail" view-title="Your Suggestions" hide-back-button="true">
+<ion-view class="your-suggestion-detail" view-title="View Suggestion" hide-back-button="true">
   <ion-nav-buttons side="left">
     <button class="button button-clear back-button"
             ui-sref="tabs.your-suggestions"
@@ -8,27 +8,35 @@
   </ion-nav-buttons>
   
   <ion-content>
+      <div class="item item-divider">Suggestion</div>
 
     <ion-item class="item-text-wrap">
       <suggestion-item suggestion="data.suggestion"></suggestion-item>
     </ion-item>
 
-    <ion-item>
-      <span ng-if="data.routes === null">Route yet to be generated!</span>
-      <span ng-if="data.routes.length === 0">No suggested routes found!</span>
-      <div ng-if="data.routes.length > 0">
-        <span class="header">Generated route</span>
+    <div class="item-divider no-text"></div>
+
+    <ion-item ng-if="data.suggestedRoute.info.status !== 'Failure'">
+      <div ng-if="data.isLoading" class="loading-bar">
+        <span class="header">Generating Route...</span>
+        <progress-bar display-label="false" backer1="loadingBar.counter" pax1="100"></progress-bar>
+      </div>
+
+      <div ng-if="data.suggestedRoute.info.status === 'Success'">
+        <span class="header">Crowdstart Route</span>
         <crowdstart-route
-          ng-repeat="route in data.routes" 
-          route="route"
-          ng-click="saveCrowdstartPreview(route)"
-          ui-sref="tabs.crowdstart-detail({ routeId: route.id ? route.id : 'preview' })">
+          route="data.suggestedRoute"
+          ng-click="saveCrowdstartPreview(data.suggestedRoute)"
+          ui-sref="tabs.crowdstart-detail({ 
+            routeId: data.suggestedRoute.id ? data.suggestedRoute.id : 'preview' 
+          })">
         </crowdstart-route>
       </div>
     </ion-item>
 
-    <div class="delete">
-      <span on-tap="popupDeleteConfirmation()">Delete Suggestion</span>
+    <div class="action-link">
+      <div on-tap="showSimilarRoutes()">View Similar Route(s)</div>
+      <div class="delete" on-tap="popupDeleteConfirmation()">Delete Suggestion</div>
     </div>
 
   </ion-content>

--- a/static/templates/your-suggestions.html
+++ b/static/templates/your-suggestions.html
@@ -4,7 +4,7 @@
   </ion-nav-buttons>
   <ion-content>
 
-    <div class="item item-divider">Your Suggestions</div>
+    <div class="item item-divider">All Suggestions</div>
 
     <!-- repeat 5 times -->
     <ion-item ng-repeat="a in [1,2,3,4,5]" ng-if="!data.suggestions">
@@ -12,13 +12,15 @@
     </ion-item>
 
     <ion-item ng-repeat="suggestion in data.suggestions" class="item-text-wrap">
-      <suggestion-item suggestion="suggestion" ui-sref="tabs.your-suggestion-detail({ suggestionId: suggestion.id })">
+      <suggestion-item suggestion="suggestion" ng-click="viewSuggestionDetail(suggestion)">
       </suggestion-item>
     </ion-item>
 
-    <button class="primary-button create-suggestion-btn" ui-sref="tabs.create-new-suggestion">
-      Create new suggestion
-    </button>
+    <div class="create-suggestion-btn">
+      <button class="primary-button" ui-sref="tabs.create-new-suggestion">
+        Create new suggestion
+      </button>
+    </div>
 
   </ion-content>
 </ion-view>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,55 +1,55 @@
 /* eslint no-console: 0 */
-const path = require("path")
-const assert = require("assert")
-const InlineEnviromentVariablesPlugin = require("inline-environment-variables-webpack-plugin")
+const path = require('path')
+const assert = require('assert')
+const InlineEnviromentVariablesPlugin = require('inline-environment-variables-webpack-plugin')
 
-const prefix = process.env.BUILD_PREFIX || "www"
+const prefix = process.env.BUILD_PREFIX || 'www'
 
-const INLINED_ENVIRONMENT_VARIABLES = ["BACKEND_URL", "TRACKING_URL"]
+const INLINED_ENVIRONMENT_VARIABLES = ['BACKEND_URL', 'TRACKING_URL']
 
-INLINED_ENVIRONMENT_VARIABLES.forEach(function(key) {
-  assert(process.env[key], "process.env." + key + " must be set")
+INLINED_ENVIRONMENT_VARIABLES.forEach(function (key) {
+  assert(process.env[key], 'process.env.' + key + ' must be set')
 })
 
-module.exports = function(env) {
+module.exports = function (env) {
   env = env || {}
   return [
     // Javascript Config
     {
-      devtool: "source-map",
+      devtool: 'source-map',
       module: {
         rules: [
           // Enable ES6 goodness
           {
             test: /\.js$/,
-            loader: "babel-loader",
+            loader: 'babel-loader',
             exclude: /node_modules/,
           },
           // Allow HTML imports
           {
             test: /\.html$/,
-            loader: "html-loader",
+            loader: 'html-loader',
             options: { attrs: false }, // disable img:src loading
           },
           // Allow JSON imports
           {
             test: /\.json$/,
-            loader: "json-loader",
+            loader: 'json-loader',
           },
           // Fix for libraries that require globals
           {
             test: require.resolve(
-              "multiple-date-picker/dist/multipleDatePicker"
+              'multiple-date-picker/dist/multipleDatePicker'
             ),
-            loader: "imports-loader?moment",
+            loader: 'imports-loader?moment',
           },
         ],
       },
-      entry: ["babel-polyfill", path.resolve("beeline/main.js")],
+      entry: ['babel-polyfill', path.resolve('beeline/main.js')],
       output: {
-        path: path.resolve(prefix, "lib/beeline"),
-        filename: "bundle.js",
-        pathinfo: env.production ? false : true,
+        path: path.resolve(prefix, 'lib/beeline'),
+        filename: 'bundle.js',
+        pathinfo: !env.production,
       },
       plugins: [
         new InlineEnviromentVariablesPlugin(INLINED_ENVIRONMENT_VARIABLES),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const InlineEnviromentVariablesPlugin = require('inline-environment-variables-we
 
 const prefix = process.env.BUILD_PREFIX || 'www'
 
-const INLINED_ENVIRONMENT_VARIABLES = ['BACKEND_URL', 'TRACKING_URL']
+const INLINED_ENVIRONMENT_VARIABLES = ['BACKEND_URL', 'TRACKING_URL', 'ROUTING_URL']
 
 INLINED_ENVIRONMENT_VARIABLES.forEach(function (key) {
   assert(process.env[key], 'process.env.' + key + ' must be set')


### PR DESCRIPTION
Changes have been made to beeline-routing so that it can independently handle route generation trigger requests; beeline-frontend has thus been modified to exploit that

TODO:
* Poll `/suggested_routes` from beeline-routing
* Migrate other suggestions endpoints to beeline-routing(?)