### PR TITLE
Avoid fetching routes where possible

### DIFF
--- a/beeline/controllers/BookingDatesController.js
+++ b/beeline/controllers/BookingDatesController.js
@@ -191,11 +191,17 @@ export default [
     // Data Loading
     // ------------------------------------------------------------------------
     let multipleDatePopup = null
+
+    // look up the route passes the user has, then tally up the
+    // route passes remaining across the route's tags
     const routePromise = loadRoutes()
-    const ridesRemainingPromise = RoutesService.fetchRoutePassCount()
-    $q.all([routePromise, ridesRemainingPromise]).then(function (values) {
-      let ridesRemainingMap = values[1]
-      $scope.book.route.ridesRemaining = ridesRemainingMap[routeId]
+    const ridesRemainingPromise = RoutesService.fetchRoutePasses()
+    $q.all([routePromise, ridesRemainingPromise]).then(function ([, ridesRemainingMap]) {
+      let ridesRemaining = 0
+      $scope.book.route.tags.forEach(tag => {
+        ridesRemaining += (ridesRemainingMap[tag] || 0)
+      })
+      $scope.book.route.ridesRemaining = ridesRemaining
     })
 
     // ------------------------------------------------------------------------

--- a/beeline/controllers/RouteDetailController.js
+++ b/beeline/controllers/RouteDetailController.js
@@ -290,7 +290,7 @@ export default [
         'data.route',
         () => RoutesService.getRoutePasses(),
       ],
-      async ([route, ridesRemainingMap]) => {
+      ([route, ridesRemainingMap]) => {
         if (route && route.tags && ridesRemainingMap) {
           let ridesRemaining = 0
           route.tags.forEach(tag => {

--- a/beeline/controllers/RouteDetailController.js
+++ b/beeline/controllers/RouteDetailController.js
@@ -57,7 +57,7 @@ export default [
 
     const initExpiryModal = function initExpiryModal () {
       let scope = $rootScope.$new()
-      scope.routeId = $scope.data.routeId
+      scope.route = $scope.data.route
 
       let modal = $ionicModal.fromTemplate(expiryModalTemplate, {
         scope,
@@ -285,10 +285,19 @@ export default [
     })
 
     // Get the route passes
-    $scope.$watch(
-      () => RoutesService.getPassCountForRoute(routeId),
-      passCount => {
-        $scope.data.passCount = passCount
+    $scope.$watchGroup(
+      [
+        'data.route',
+        () => RoutesService.getRoutePasses(),
+      ],
+      async ([route, ridesRemainingMap]) => {
+        if (route && route.tags && ridesRemainingMap) {
+          let ridesRemaining = 0
+          route.tags.forEach(tag => {
+            ridesRemaining += (ridesRemainingMap[tag] || 0)
+          })
+          $scope.data.passCount = ridesRemaining
+        }
       }
     )
 

--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -28,15 +28,17 @@ export default [
     // ------------------------------------------------------------------------
     const addExpiryToRoute = function addExpiryToRoute (
       route,
-      routePassTags,
       routePassExpiries
     ) {
+      // map the expiry dates of the route passes keyed by
+      // the route's tags into expiries
       let expiries = {}
-      if (!routePassTags[route.id]) {
+      const scopedTags = _.intersection(route.tags, _.keys(routePassExpiries))
+      if (scopedTags.length === 0) {
         return route
       }
 
-      for (let tag of routePassTags[route.id]) {
+      for (let tag of scopedTags) {
         _.assign(expiries, routePassExpiries[tag])
       }
       let dates = Object.keys(expiries).map(date => {
@@ -227,14 +229,12 @@ export default [
     // Add expiry to routes
     $scope.$watchGroup(
       [
-        () => RoutesService.getRoutePassTags(),
         () => RoutesService.getRoutePassExpiries(),
         'data.routesWithRidesRemaining',
         'data.recentRoutes',
       ],
       (
         [
-          routePassTags,
           routePassExpiries,
           routesWithRidesRemaining,
           recentRoutes,
@@ -242,7 +242,6 @@ export default [
       ) => {
         // Input validation
         if (
-          !routePassTags ||
           !routePassExpiries ||
           !routesWithRidesRemaining ||
           !recentRoutes
@@ -258,7 +257,7 @@ export default [
           recentRoutes,
         ].map(routes => {
           return routes.map(route => {
-            return addExpiryToRoute(route, routePassTags, routePassExpiries)
+            return addExpiryToRoute(route, routePassExpiries)
           })
         })
 

--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -30,10 +30,10 @@ export default [
       route,
       routePassExpiries
     ) {
-      // map the expiry dates of the route passes keyed by
-      // the route's tags into expiries
+      // Create a map of the route's tags into corresponding expiry dates
       let expiries = {}
       const scopedTags = _.intersection(route.tags, _.keys(routePassExpiries))
+      // If there are no tags to map, return the route as-is
       if (scopedTags.length === 0) {
         return route
       }

--- a/beeline/controllers/RoutesSearchController.js
+++ b/beeline/controllers/RoutesSearchController.js
@@ -85,7 +85,6 @@ export default [
       // Refresh routes on enter for routes in case we did something that
       // changed my routes e.g. unsubscribing lite route, booking a route,
       // withdrawing from crowdstart
-      $scope.refreshRoutes(true)
       redrawMapElements()
     })
 
@@ -104,7 +103,7 @@ export default [
     // ------------------------------------------------------------------------
     // UI Hooks
     // ------------------------------------------------------------------------
-    $scope.search = function () {
+    $scope.search = async function () {
       let pickUp = $scope.data.pickUpLocation
       let dropOff = $scope.data.dropOffLocation
 
@@ -127,13 +126,14 @@ export default [
         template: `<ion-spinner icon='crescent'></ion-spinner><br/><small>Searching for routes</small>`,
       })
 
-      $timeout(() => {
-        $ionicLoading.hide()
-        $state.go('tabs.routes-search-list', {
-          pickUpLocation: pickUp,
-          dropOffLocation: dropOff,
-        })
-      }, 800)
+      await $scope.refreshRoutes()
+
+      $ionicLoading.hide()
+
+      $state.go('tabs.routes-search-list', {
+        pickUpLocation: pickUp,
+        dropOffLocation: dropOff,
+      })
     }
 
     // Manually pull the newest data from the server
@@ -141,9 +141,7 @@ export default [
     // Note that theres no need to update the scope manually
     // since this is done by the service watchers
     $scope.refreshRoutes = function (ignoreCache) {
-      RoutesService.fetchRoutePasses(ignoreCache)
-      RoutesService.fetchRoutes(ignoreCache)
-      const routesPromise = RoutesService.fetchRoutesWithRoutePass()
+      const routesPromise = RoutesService.fetchRoutesWithRoutePass(ignoreCache)
       const recentRoutesPromise = RoutesService.fetchRecentRoutes(ignoreCache)
       const allLiteRoutesPromise = LiteRoutesService.fetchLiteRoutes(
         ignoreCache

--- a/beeline/directives/priceCalculator/priceCalculator.js
+++ b/beeline/directives/priceCalculator/priceCalculator.js
@@ -28,14 +28,16 @@ angular.module('beeline').directive('priceCalculator', [
             $scope.booking.promoCode = promoCode
           }
 
+          /**
+           * Update ridesRemaining when user login at the booking summary page
+           * look up the route passes the user has, then tally up the
+           * route passes remaining across the route's tags
+           */
           const toggleApplyRoutePass = async function toggleApplyRoutePass () {
             if (!$scope.booking.route) {
               assert($scope.booking.routeId)
               $scope.booking.route = await RoutesService.getRoute($scope.booking.routeId)
             }
-            // update ridesRemaining when user login at the booking summary page
-            // look up the route passes the user has, then tally up the
-            // route passes remaining across the route's tags
             RoutesService.fetchRoutePasses().then(ridesRemainingMap => {
               if (ridesRemainingMap) {
                 let ridesRemaining = 0
@@ -47,6 +49,7 @@ angular.module('beeline').directive('priceCalculator', [
               }
             })
           }
+
           $scope.$watch(
             () => UserService.getUser(),
             async user => {

--- a/beeline/directives/priceCalculator/priceCalculator.js
+++ b/beeline/directives/priceCalculator/priceCalculator.js
@@ -28,33 +28,30 @@ angular.module('beeline').directive('priceCalculator', [
             $scope.booking.promoCode = promoCode
           }
 
+          const toggleApplyRoutePass = async function toggleApplyRoutePass () {
+            if (!$scope.booking.route) {
+              assert($scope.booking.routeId)
+              $scope.booking.route = await RoutesService.getRoute($scope.booking.routeId)
+            }
+            // update ridesRemaining when user login at the booking summary page
+            // look up the route passes the user has, then tally up the
+            // route passes remaining across the route's tags
+            RoutesService.fetchRoutePasses().then(ridesRemainingMap => {
+              if (ridesRemainingMap) {
+                let ridesRemaining = 0
+                $scope.booking.route.tags.forEach(tag => {
+                  ridesRemaining += (ridesRemainingMap[tag] || 0)
+                })
+                $scope.booking.applyRoutePass = ridesRemaining > 0
+                $scope.booking.route.ridesRemaining = ridesRemaining
+              }
+            })
+          }
           $scope.$watch(
             () => UserService.getUser(),
-            user => {
+            async user => {
               $scope.isLoggedIn = !!user
-
-              // update ridesRemaining when user login at the booking summary page
-              RoutesService.fetchRoutePassCount().then(routePassCountMap => {
-                assert($scope.booking.routeId)
-                if (!$scope.booking.route) {
-                  RoutesService.getRoute($scope.booking.routeId).then(route => {
-                    $scope.booking.route = route
-                    if (routePassCountMap) {
-                      $scope.booking.route.ridesRemaining =
-                        routePassCountMap[$scope.booking.routeId]
-                      $scope.booking.applyRoutePass =
-                        $scope.booking.route.ridesRemaining > 0
-                    }
-                  })
-                } else {
-                  if (routePassCountMap) {
-                    $scope.booking.route.ridesRemaining =
-                      routePassCountMap[$scope.booking.routeId]
-                    $scope.booking.applyRoutePass =
-                      $scope.booking.route.ridesRemaining > 0
-                  }
-                }
-              })
+              await toggleApplyRoutePass()
             }
           )
           /**
@@ -62,14 +59,7 @@ angular.module('beeline').directive('priceCalculator', [
            */
           const recomputePrices = async function recomputePrices () {
             assert($scope.booking.routeId)
-            if (!$scope.booking.route) {
-              $scope.booking.route = await RoutesService.getRoute(
-                $scope.booking.routeId
-              )
-              let routeToRidesRemainingMap = await RoutesService.fetchRoutePassCount()
-              $scope.booking.route.ridesRemaining =
-                routeToRidesRemainingMap[$scope.booking.routeId]
-            }
+            await toggleApplyRoutePass()
 
             // Provide a price summary first (don't count total due)
             // This allows the page to resize earlier, so that when

--- a/beeline/directives/routePassExpiry/routePassExpiryModal.js
+++ b/beeline/directives/routePassExpiry/routePassExpiryModal.js
@@ -10,24 +10,26 @@ angular.module('beeline').directive('routePassExpiryModal', [
       restrict: 'E',
       template: expiryModalTemplate,
       scope: {
-        routeId: '@',
+        route: '=',
         modal: '=',
       },
       link: function (scope, element, attributes) {
         scope.$watchGroup(
           [
-            () => RoutesService.getRoutePassTags(),
             () => RoutesService.getRoutePassExpiries(),
+            'route',
           ],
-          ([routePassTags, routePassExpiries]) => {
+          ([routePassExpiries, route]) => {
             // Input validation
-            if (!routePassTags || !routePassExpiries) return
+            if (!route || !route.tags || !routePassExpiries) return
 
-            let tags = routePassTags[scope.routeId]
+            // map the expiry dates of the route passes keyed by
+            // the route's tags into expiries
             let expiries = {}
-            if (!tags) return
-            for (let tag of tags) {
-              _.assign(expiries, routePassExpiries[tag])
+            for (let tag of route.tags) {
+              if (tag in routePassExpiries) {
+                _.assign(expiries, routePassExpiries[tag])
+              }
             }
 
             let expiryInfo = []

--- a/beeline/main.js
+++ b/beeline/main.js
@@ -415,7 +415,8 @@ app
       TicketService,
       SuggestionService
     ) {
-      // Pre-fetch the routes
+      // Pre-fetch user data
+      RoutesService.fetchRoutePasses()
       RoutesService.fetchRecentRoutes()
       CrowdstartService.fetchBids()
       TicketService.fetchTickets()

--- a/beeline/main.js
+++ b/beeline/main.js
@@ -407,22 +407,17 @@ app
   .run([
     'RoutesService',
     'CrowdstartService',
-    'LiteRoutesService',
     'TicketService',
     'SuggestionService',
     function (
       RoutesService,
       CrowdstartService,
-      LiteRoutesService,
       TicketService,
       SuggestionService
     ) {
       // Pre-fetch the routes
-      RoutesService.fetchRoutes()
       RoutesService.fetchRecentRoutes()
-      CrowdstartService.fetchCrowdstart()
       CrowdstartService.fetchBids()
-      LiteRoutesService.fetchLiteRoutes()
       TicketService.fetchTickets()
       SuggestionService.fetchSuggestions()
     },

--- a/beeline/services/data/CrowdstartService.js
+++ b/beeline/services/data/CrowdstartService.js
@@ -190,8 +190,6 @@ angular.module('beeline').service('CrowdstartService', [
 
     UserService.userEvents.on('userChanged', () => {
       fetchBids(true)
-      // to load route passes
-      RoutesService.fetchRoutePassCount(true)
     })
 
     const refresh = function refresh () {

--- a/beeline/services/data/RoutesService.js
+++ b/beeline/services/data/RoutesService.js
@@ -86,12 +86,8 @@ angular.module('beeline').factory('RoutesService', [
     UserService.userEvents.on('userChanged', () => {
       instance.fetchRecentRoutes(true)
       instance.fetchRoutePasses(true)
-      instance.fetchRoutesWithRoutePass()
       instance.fetchRecentRoutes(true)
       instance.fetchRoutePassExpiries(true)
-      instance.fetchRoutePassTags(true)
-      instance.fetchPrivateRoutes(true)
-      instance.fetchPrivateRoutesWithRoutePass(true)
     })
 
     let instance = {

--- a/beeline/services/paymentService.js
+++ b/beeline/services/paymentService.js
@@ -47,8 +47,6 @@ angular.module('beeline').factory('PaymentService', [
         TicketService.setShouldRefreshTickets()
       } finally {
         RoutesService.fetchRoutePasses(true)
-        RoutesService.fetchRoutePassCount()
-        RoutesService.fetchRoutesWithRoutePass()
       }
     }
 
@@ -210,8 +208,6 @@ angular.module('beeline').factory('PaymentService', [
           })
         } finally {
           RoutesService.fetchRoutePasses(true)
-          RoutesService.fetchRoutePassCount()
-          RoutesService.fetchRoutesWithRoutePass()
         }
         return paymentPromise
       },

--- a/beeline/templates/route-pass-expiry-modal.html
+++ b/beeline/templates/route-pass-expiry-modal.html
@@ -1,1 +1,1 @@
-<route-pass-expiry-modal route-id="{{ routeId }}" modal="modal"></route-pass-expiry-modal>
+<route-pass-expiry-modal route="route" modal="modal"></route-pass-expiry-modal>


### PR DESCRIPTION
Current implementations of fetching route pass count involve making
calls to fetch all the routes to translate route ids to tags for
a user's route passes, which are keyed by tag, not id. This is
excessive and has contributed to load issues, especially given that
the only time we need the route pass count is when we are transacting
on _a single route_.

Further, eager fetching of routes on init is generally helpful only for
search, and nothing more.

- At init, drop all method calls that make a `GET /routes` request
- On `userChanged`, drop all method calls that make `GET /routes`
- RoutesSearchController does not need to `GET /routes` on load
- When searching, make use of cached entries if available, as routes
  do not get added frequently anyway
- Rework the route pass logic to infer route pass counts by fetching
the route pass counts keyed by tag, then cross-checking against
the current route