### PR TITLE
Remove dependency on `/crowdstart/status`

### DIFF
--- a/beeline/controllers/CrowdstartDetailController.js
+++ b/beeline/controllers/CrowdstartDetailController.js
@@ -69,25 +69,13 @@ export default [
     })
 
     $scope.$on('$ionicView.enter', function () {
+      const routePromise = CrowdstartService.fetchCrowdstartById($scope.book.routeId)
       // For re-computing bidded correctly when re-entering the page
       updateBidded([
         UserService.getUser(),
-        CrowdstartService.getCrowdstartById($scope.book.routeId),
+        routePromise,
       ])
-      if ($ionicHistory.backView()) {
-        $scope.disp.showHamburger = false
-      } else {
-        $scope.disp.showHamburger = true
-      }
-    })
-
-    // ------------------------------------------------------------------------
-    // Watchers
-    // ------------------------------------------------------------------------
-    $scope.$watch(
-      () => CrowdstartService.getCrowdstartById($scope.book.routeId),
-      async routePromise => {
-        const route = await routePromise
+      routePromise.then(route => {
         if (!route) return
         $scope.book.route = route
         $scope.book.bidOptions = route.notes.tier
@@ -100,15 +88,21 @@ export default [
         CompanyService.getCompany(route.transportCompanyId).then(company => {
           $scope.disp.company = company
         })
+      })
+      if ($ionicHistory.backView()) {
+        $scope.disp.showHamburger = false
+      } else {
+        $scope.disp.showHamburger = true
       }
-    )
+    })
 
-    $scope.$watchGroup(
-      [
-        () => UserService.getUser(),
-        () => CrowdstartService.getCrowdstartById($scope.book.routeId),
-      ],
-      updateBidded
+    // ------------------------------------------------------------------------
+    // Watchers
+    // ------------------------------------------------------------------------
+
+    $scope.$watch(
+      () => UserService.getUser(),
+      user => updateBidded([user, CrowdstartService.fetchCrowdstartById($scope.book.routeId)])
     )
 
     // ------------------------------------------------------------------------

--- a/beeline/controllers/CrowdstartSummaryController.js
+++ b/beeline/controllers/CrowdstartSummaryController.js
@@ -9,6 +9,7 @@ export default [
   'loadingSpinner',
   'UserService',
   '$ionicPopup',
+  '$ionicLoading',
   'CrowdstartService',
   'CompanyService',
   'StripeService',
@@ -21,6 +22,7 @@ export default [
     loadingSpinner,
     UserService,
     $ionicPopup,
+    $ionicLoading,
     CrowdstartService,
     CompanyService,
     StripeService,
@@ -63,33 +65,47 @@ export default [
     $scope.book.routeId = routeId
     $scope.priceInfo.bidPrice = bidPrice
 
+    // Load the route information
+    // Show a loading overlay while we wait
+    // force reload when revisit the same route
+    $scope.$on('$ionicView.afterEnter', () => {
+      $ionicLoading.show({
+        template: `<ion-spinner icon='crescent'></ion-spinner><br/><small>Loading route information</small>`,
+      })
+
+      CrowdstartService.fetchCrowdstartById(routeId)
+        .then(route => {
+          if (!route) return
+          $scope.book.route = route
+
+          // Add expiry date to route
+          $scope.book.route.expiryDate = moment($scope.book.route.trips[0].date)
+            .add(1, 'months')
+            .format()
+
+          // give 1st and last stop as board and alight stop for fake ticket
+          $scope.book.boardStopId = _.first(route.trips[0].tripStops).id
+          $scope.book.alightStopId = _.last(route.trips[0].tripStops).id
+          $scope.priceInfo.tripCount = $scope.book.route.notes.noPasses || 0
+          $scope.priceInfo.totalDue =
+            $scope.priceInfo.bidPrice * $scope.priceInfo.tripCount
+          $scope.$watch('priceInfo.bidPrice', price => {
+            $scope.priceInfo.tripCount = $scope.book.route.notes.noPasses || 0
+            $scope.priceInfo.totalDue = price * $scope.priceInfo.tripCount
+          })
+        })
+        .catch(error => {
+          $ionicLoading.hide()
+          $ionicPopup.alert({
+            title: "Sorry there's been a problem loading the route information",
+            subTitle: error,
+          })
+        })
+    })
+
     // ------------------------------------------------------------------------
     // Watchers
     // ------------------------------------------------------------------------
-    $scope.$watch(
-      () => CrowdstartService.getCrowdstartById($scope.book.routeId),
-      async routePromise => {
-        const route = await routePromise
-        if (!route) return
-        $scope.book.route = route
-
-        // Add expiry date to route
-        $scope.book.route.expiryDate = moment($scope.book.route.trips[0].date)
-          .add(1, 'months')
-          .format()
-
-        // give 1st and last stop as board and alight stop for fake ticket
-        $scope.book.boardStopId = _.first(route.trips[0].tripStops).id
-        $scope.book.alightStopId = _.last(route.trips[0].tripStops).id
-        $scope.priceInfo.tripCount = $scope.book.route.notes.noPasses || 0
-        $scope.priceInfo.totalDue =
-          $scope.priceInfo.bidPrice * $scope.priceInfo.tripCount
-        $scope.$watch('priceInfo.bidPrice', price => {
-          $scope.priceInfo.tripCount = $scope.book.route.notes.noPasses || 0
-          $scope.priceInfo.totalDue = price * $scope.priceInfo.tripCount
-        })
-      }
-    )
 
     $scope.$watch(
       () => UserService.getUser(),

--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -6,6 +6,7 @@ export default [
   '$q',
   '$state',
   'RoutesService',
+  'RequestService',
   'CrowdstartService',
   'LiteRoutesService',
   'LiteRouteSubscriptionService',
@@ -17,6 +18,7 @@ export default [
     $state,
     // Route Information
     RoutesService,
+    RequestService,
     CrowdstartService,
     LiteRoutesService,
     // Misc
@@ -149,40 +151,35 @@ export default [
       }
     )
 
-    $scope.$watchGroup(
-      [
-        () => CrowdstartService.getBids(),
-        () => CrowdstartService.getCrowdstartRoutesById(),
-      ],
-      async ([bids, crowdstartRoutesById]) => {
-        if (!bids || !crowdstartRoutesById) return
+    $scope.$watch(
+      () => CrowdstartService.getBids(),
+      async personalBids => {
+        if (!personalBids) return
 
         const crowdstarts = await Promise.all(
-          bids.map(bid => CrowdstartService.getCrowdstartById(bid.routeId))
+          personalBids.map(async bid => CrowdstartService.fetchCrowdstartById(bid.routeId))
         )
-        $scope.data.backedCrowdstartRoutes = crowdstarts.filter(
-          route =>
-            (!route.passExpired && route.isActived) ||
-            !route.isExpired ||
-            !route.is7DaysOld
-        )
+        $scope.data.backedCrowdstartRoutes = crowdstarts
+          .filter(
+            route =>
+              (!route.passExpired && route.isActived) ||
+              !route.isExpired ||
+              !route.is7DaysOld
+          )
       }
     )
 
     // Lite routes
-    $scope.$watchGroup(
-      [
-        () => LiteRoutesService.getLiteRoutes(),
-        () => LiteRouteSubscriptionService.getSubscriptionSummary(),
-      ],
-      ([liteRoutes, subscribed]) => {
-        // Input validation
-        if (!liteRoutes || !subscribed) return
-        liteRoutes = Object.values(liteRoutes)
-
-        let subscribedLiteRoutes = _.filter(liteRoutes, route => {
-          return !!subscribed.includes(route.label)
-        })
+    $scope.$watch(
+      () => LiteRouteSubscriptionService.getSubscriptionSummary(),
+      async labels => {
+        let subscribedLiteRoutes = await Promise.all(
+          labels.map(async label => {
+            const routeByLabel = await LiteRoutesService.fetchLiteRoutes(true, { label })
+            const [ route ] = Object.values(routeByLabel)
+            return route
+          })
+        )
         // Sort by label and publish
         $scope.data.subscribedLiteRoutes = _.sortBy(
           subscribedLiteRoutes,
@@ -290,26 +287,15 @@ export default [
     // since this is done by the service watchers
     $scope.refreshRoutes = function (ignoreCache) {
       RoutesService.fetchRoutePasses(ignoreCache)
-      RoutesService.fetchRoutes(ignoreCache)
-      const routesPromise = RoutesService.fetchRoutesWithRoutePass()
       const recentRoutesPromise = RoutesService.fetchRecentRoutes(ignoreCache)
-      const allLiteRoutesPromise = LiteRoutesService.fetchLiteRoutes(
-        ignoreCache
-      )
-      const crowdstartRoutesPromise = CrowdstartService.fetchCrowdstart(
-        ignoreCache
-      )
       const liteRouteSubscriptionsPromise = LiteRouteSubscriptionService.getSubscriptions(
         ignoreCache
       )
       const bidsPromise = CrowdstartService.fetchBids(ignoreCache)
       return $q
         .all([
-          routesPromise,
           recentRoutesPromise,
-          allLiteRoutesPromise,
           liteRouteSubscriptionsPromise,
-          crowdstartRoutesPromise,
           bidsPromise,
         ])
         .then(() => {

--- a/beeline/controllers/RoutesListController.js
+++ b/beeline/controllers/RoutesListController.js
@@ -157,7 +157,7 @@ export default [
         if (!personalBids) return
 
         const crowdstarts = await Promise.all(
-          personalBids.map(async bid => CrowdstartService.fetchCrowdstartById(bid.routeId))
+          personalBids.map(bid => CrowdstartService.fetchCrowdstartById(bid.routeId))
         )
         $scope.data.backedCrowdstartRoutes = crowdstarts
           .filter(
@@ -176,8 +176,7 @@ export default [
         let subscribedLiteRoutes = await Promise.all(
           labels.map(async label => {
             const routeByLabel = await LiteRoutesService.fetchLiteRoutes(true, { label })
-            const [ route ] = Object.values(routeByLabel)
-            return route
+            return routeByLabel[label]
           })
         )
         // Sort by label and publish

--- a/beeline/services/data/CrowdstartService.js
+++ b/beeline/services/data/CrowdstartService.js
@@ -193,10 +193,7 @@ angular.module('beeline').service('CrowdstartService', [
     })
 
     const refresh = function refresh () {
-      return Promise.all([
-        fetchCrowdstartRoutes(true),
-        fetchBids(true),
-      ])
+      return fetchBids(true)
     }
 
     // first load
@@ -232,11 +229,22 @@ angular.module('beeline').service('CrowdstartService', [
       return lastPrivateCrowdstartRoutePromise
     }
 
+    const fetchCrowdstartById = async function fetchCrowdstartById (routeId) {
+      const [ route, bids ] = await Promise.all([
+        RoutesService.getRoute(routeId, true, { startDate: 0 }),
+        RequestService.beeline({
+          method: 'GET',
+          url: `/crowdstart/routes/${routeId}/bids`,
+        }).then(response => response.data),
+      ])
+      return transformCrowdstartData([ Object.assign(route, { bids }) ])[0]
+    }
+
     return {
       // all crowdstart routes
       getCrowdstart: () => crowdstartRoutesList,
       fetchCrowdstart: ignoreCache => fetchCrowdstartRoutes(ignoreCache),
-
+      fetchCrowdstartById,
       getCrowdstartById: function (routeId) {
         if (routeId === 'preview') {
           transformCrowdstartData([crowdstartPreview])

--- a/beeline/services/data/LiteRoutesService.js
+++ b/beeline/services/data/LiteRoutesService.js
@@ -28,14 +28,17 @@ angular.module('beeline').factory('LiteRoutesService', [
     // But limits the amount of data retrieved
     // getRoutes() now returns a list of routes, but with very limited
     // trip data (limited to 5 trips, no path)
-    const fetchLiteRoutes = function fetchLiteRoutes (ignoreCache) {
-      if (liteRoutesCache && !ignoreCache) {
+    const fetchLiteRoutes = function fetchLiteRoutes (ignoreCache, options) {
+      if (liteRoutesCache && !ignoreCache && !options) {
         return liteRoutesCache
       }
 
-      let finalOptions = p.transportCompanyId
-        ? { transportCompanyId: p.transportCompanyId }
-        : {}
+      let finalOptions = Object.assign(
+        p.transportCompanyId
+          ? { transportCompanyId: p.transportCompanyId }
+          : {},
+        options || {}
+      )
 
       let url = '/routes/lite?' + querystring.stringify(finalOptions)
       let liteRoutesPromise = inFlightRouteRequests[url]
@@ -48,8 +51,10 @@ angular.module('beeline').factory('LiteRoutesService', [
 
         liteRoutesPromise = inFlightRouteRequests[url] = request
           .then(response => {
-            liteRoutes = response.data
-            return liteRoutes
+            if (!options) {
+              liteRoutes = response.data
+            }
+            return response.data
           })
           .finally(() => delete inFlightRouteRequests[url])
 

--- a/beeline/services/data/LiteRoutesService.js
+++ b/beeline/services/data/LiteRoutesService.js
@@ -28,17 +28,20 @@ angular.module('beeline').factory('LiteRoutesService', [
     // But limits the amount of data retrieved
     // getRoutes() now returns a list of routes, but with very limited
     // trip data (limited to 5 trips, no path)
+    // options specifies query parameters to send to `/routes/lite`.
+    // if options specified, cache implicitly ignored
     const fetchLiteRoutes = function fetchLiteRoutes (ignoreCache, options) {
       if (liteRoutesCache && !ignoreCache && !options) {
         return liteRoutesCache
       }
 
-      let finalOptions = Object.assign(
-        p.transportCompanyId
-          ? { transportCompanyId: p.transportCompanyId }
-          : {},
-        options || {}
-      )
+      // If transportCompanyId is globally set, eg in GrabShuttle,
+      // coerce this option into query params to send
+      const transportCompanyIdOptions = p.transportCompanyId
+        ? { transportCompanyId: p.transportCompanyId }
+        : {}
+
+      const finalOptions = Object.assign(transportCompanyIdOptions, options || {})
 
       let url = '/routes/lite?' + querystring.stringify(finalOptions)
       let liteRoutesPromise = inFlightRouteRequests[url]

--- a/static/grab.html
+++ b/static/grab.html
@@ -42,7 +42,6 @@
   <script src="lib/ionic/js/ionic.bundle.min.js"></script>
   <!-- cordova script (this will be a 404 during development) -->
   <script src="js/ng-cordova.min.js"></script>
-  <script src="cordova.js"></script>
   <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
   <script type="text/javascript" src="https://checkout.stripe.com/checkout.js"></script>
   <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -41,7 +41,6 @@
   <!-- ionic/angularjs js -->
   <script src="lib/ionic/js/ionic.bundle.min.js"></script>
   <script src="js/ng-cordova.min.js"></script>
-  <script src="cordova.js"></script>
   <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
   <script type="text/javascript" src="https://checkout.stripe.com/checkout.js"></script>
   <script defer src="https://use.fontawesome.com/releases/v5.0.8/js/all.js"></script>


### PR DESCRIPTION
RoutesListController was still reliant on bulk load of query on
entering the view. Rework it to fetch only the routes it cares about,
with corresponding changes to crowdstart controllers

- LiteRoutesService: allow querying of routes by label
- CrowdstartService: implement fetching of crowdstart routes by id
- RoutesListController: rework watchers to fetch route data manually,
  instead of relying on bulk fetching of data
- Crowdstart controllers: fetch route data from backend on init,
  instead of waiting on bulk fetching